### PR TITLE
Get Path without `-p`

### DIFF
--- a/sidekick/lib/src/init/init_command.dart
+++ b/sidekick/lib/src/init/init_command.dart
@@ -92,7 +92,8 @@ class InitCommand extends Command {
 
 /// Initializes git via `git init` in [directory]
 Future<void> gitInit(Directory directory) async {
-  final Process process = await Process.start('git', ['init']);
+  final Process process =
+      await Process.start('git', ['init'], workingDirectory: directory.path);
   stdout.addStream(process.stdout);
   stderr.addStream(process.stderr);
   await process.exitCode;

--- a/sidekick/lib/src/init/init_command.dart
+++ b/sidekick/lib/src/init/init_command.dart
@@ -18,7 +18,8 @@ class InitCommand extends Command {
     argParser.addOption(
       'cliName',
       abbr: 'n',
-      help: 'The name of the CLI to be created \nThe `_cli` prefix, will be define automatically',
+      help:
+          'The name of the CLI to be created \nThe `_cli` prefix, will be define automatically',
     );
   }
 
@@ -77,7 +78,8 @@ class InitCommand extends Command {
 
     // Generate the package code
     final generator = await MasonGenerator.fromBundle(cliBundle);
-    final generatorTarget = DirectoryGeneratorTarget(path, Logger(), FileConflictResolution.prompt);
+    final generatorTarget =
+        DirectoryGeneratorTarget(path, Logger(), FileConflictResolution.prompt);
     await generator.generate(generatorTarget, vars: {'name': cliName});
 
     // Make the entrypoint executable
@@ -102,7 +104,8 @@ Future<void> gitInit(Directory directory) async {
 /// Installs the [flutter_wrapper](https://github.com/passsy/flutter_wrapper) in
 /// [directory] using the provided install script
 Future<void> installFlutterWrapper(Directory directory) async {
-  const installUri = 'https://raw.githubusercontent.com/passsy/flutter_wrapper/master/install.sh';
+  const installUri =
+      'https://raw.githubusercontent.com/passsy/flutter_wrapper/master/install.sh';
   final content = (await http.get(Uri.parse(installUri))).body;
   final Process process = await Process.start(
     'sh',

--- a/sidekick/test/init_test.dart
+++ b/sidekick/test/init_test.dart
@@ -10,10 +10,9 @@ void main() {
   group('project type detection', () {
     test('init generates cli files', () async {
       final project = setupTemplateProject('test/templates/root_with_packages');
-      final process =
-          await sidekickCli(['init', '-n', 'dash'], workingDirectory: project);
+      final process = await sidekickCli(['init', '-n', 'dash'], workingDirectory: project);
 
-      await expectLater(process.stdout, emitsThrough('Generating dash cli'));
+      await expectLater(process.stdout, emitsThrough('Generating dash_cli'));
       printOnFailure(await process.stdoutStream().join('\n'));
       printOnFailure(await process.stderrStream().join('\n'));
       await process.shouldExit(0);
@@ -34,8 +33,7 @@ void main() {
 
     test('entrypoint executes fine after sidekick init', () async {
       final project = setupTemplateProject('test/templates/root_with_packages');
-      final process =
-          await sidekickCli(['init', '-n', 'dash'], workingDirectory: project);
+      final process = await sidekickCli(['init', '-n', 'dash'], workingDirectory: project);
       await process.shouldExit(0);
       final entrypoint = File("${project.path}/dash");
       expect(entrypoint.existsSync(), isTrue);

--- a/sidekick/test/init_test.dart
+++ b/sidekick/test/init_test.dart
@@ -10,7 +10,8 @@ void main() {
   group('project type detection', () {
     test('init generates cli files', () async {
       final project = setupTemplateProject('test/templates/root_with_packages');
-      final process = await sidekickCli(['init', '-n', 'dash'], workingDirectory: project);
+      final process =
+          await sidekickCli(['init', '-n', 'dash'], workingDirectory: project);
 
       await expectLater(process.stdout, emitsThrough('Generating dash_cli'));
       printOnFailure(await process.stdoutStream().join('\n'));
@@ -33,10 +34,41 @@ void main() {
 
     test('entrypoint executes fine after sidekick init', () async {
       final project = setupTemplateProject('test/templates/root_with_packages');
-      final process = await sidekickCli(['init', '-n', 'dash'], workingDirectory: project);
+      final process =
+          await sidekickCli(['init', '-n', 'dash'], workingDirectory: project);
       await process.shouldExit(0);
       final entrypoint = File("${project.path}/dash");
       expect(entrypoint.existsSync(), isTrue);
+
+      final dashProcess = await TestProcess.start(
+        entrypoint.path,
+        [],
+        workingDirectory: project.path,
+      );
+      printOnFailure(await dashProcess.stdoutStream().join('\n'));
+      printOnFailure(await dashProcess.stderrStream().join('\n'));
+      dashProcess.shouldExit(0);
+    });
+
+    test('init with path (absolute)', () async {
+      final project = setupTemplateProject('test/templates/root_with_packages');
+      final process = await sidekickCli(
+          ['init', '-n', 'dash', project.absolute.path],
+          workingDirectory: project.parent);
+      await process.shouldExit(0);
+
+      // check git is initialized
+      final git = Directory("${project.path}/.git");
+      expect(git.existsSync(), isTrue);
+
+      // check entrypoint is executable
+      final entrypoint = File("${project.path}/dash");
+      expect(entrypoint.existsSync(), isTrue);
+      expect(entrypoint.statSync().modeString(), 'rwxr-xr-x');
+
+      // check flutterw exists
+      final flutterw = File("${project.path}/flutterw");
+      expect(flutterw.existsSync(), isTrue);
 
       final dashProcess = await TestProcess.start(
         entrypoint.path,

--- a/sidekick/test/init_test.dart
+++ b/sidekick/test/init_test.dart
@@ -54,7 +54,7 @@ void main() {
       final project = setupTemplateProject('test/templates/root_with_packages');
       final process = await sidekickCli(
           ['init', '-n', 'dash', project.absolute.path],
-          workingDirectory: project.parent);
+          workingDirectory: project.parent,);
       await process.shouldExit(0);
 
       // check git is initialized


### PR DESCRIPTION
Before:
User was forced to use `-p` to define a path where sidekick should fulfil its magic

Now:

User can just pass the path into the `init` command without an additional `-p`