### PR TITLE
Pin the mason cli version + dependencies in pubspec

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -17,6 +17,8 @@ jobs:
       - run: |
          apt-get update
       - uses: actions/checkout@v1
+      - name: Intall deps
+        run: cd sidekick && dart pub get --no-precompile
       - name: Install Mason and export path in the Github CI and pull the updated path
         run: |
           set -e

--- a/sidekick/pubspec.lock
+++ b/sidekick/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "36.0.0"
+    version: "38.0.0"
   acronym:
     dependency: "direct main"
     description:
@@ -21,14 +21,14 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.1"
+    version: "3.4.1"
   archive:
     dependency: transitive
     description:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.0"
   args:
     dependency: "direct main"
     description:
@@ -105,7 +105,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -119,7 +119,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   crypto:
     dependency: transitive
     description:
@@ -154,21 +154,14 @@ packages:
       name: dcli
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.2"
+    version: "1.16.3"
   dcli_core:
     dependency: transitive
     description:
       name: dcli_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.6"
-  di_zone2:
-    dependency: transitive
-    description:
-      name: di_zone2
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
+    version: "0.0.7"
   equatable:
     dependency: transitive
     description:
@@ -190,6 +183,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.2"
+  file_utils:
+    dependency: transitive
+    description:
+      name: file_utils
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   frontend_server_client:
     dependency: transitive
     description:
@@ -204,6 +204,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
+  globbing:
+    dependency: transitive
+    description:
+      name: globbing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   http:
     dependency: "direct main"
     description:
@@ -259,7 +266,7 @@ packages:
       name: lint
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.2"
+    version: "1.8.2"
   logging:
     dependency: transitive
     description:
@@ -350,7 +357,7 @@ packages:
       name: pointycastle
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.1"
+    version: "3.5.2"
   pool:
     dependency: transitive
     description:
@@ -378,7 +385,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   pub_updater:
     dependency: transitive
     description:
@@ -392,7 +399,7 @@ packages:
       name: pubspec
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   quiver:
     dependency: transitive
     description:
@@ -414,6 +421,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  scope:
+    dependency: transitive
+    description:
+      name: scope
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
   settings_yaml:
     dependency: transitive
     description:
@@ -455,7 +469,7 @@ packages:
       name: sidekick_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.2"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -505,6 +519,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  system_info2:
+    dependency: transitive
+    description:
+      name: system_info2
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   term_glyph:
     dependency: transitive
     description:
@@ -518,7 +539,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.20.1"
+    version: "1.20.2"
   test_api:
     dependency: transitive
     description:
@@ -595,7 +616,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.2.0"
+    version: "8.2.2"
   watcher:
     dependency: transitive
     description:
@@ -632,4 +653,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.4 <3.0.0"
+  dart: ">=2.15.0-7.0.dev <3.0.0"

--- a/sidekick/pubspec.lock
+++ b/sidekick/pubspec.lock
@@ -245,7 +245,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.3"
   json_annotation:
     dependency: transitive
     description:
@@ -259,7 +259,7 @@ packages:
       name: lint
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.7.2"
   logging:
     dependency: transitive
     description:
@@ -274,13 +274,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0-dev.4"
+  mason_cli:
+    dependency: "direct dev"
+    description:
+      name: mason_cli
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0-dev.6"
   mason_logger:
     dependency: transitive
     description:
       name: mason_logger
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-dev.5"
+    version: "0.1.0-dev.4"
   matcher:
     dependency: transitive
     description:
@@ -330,6 +337,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
   pointycastle:
     dependency: transitive
     description:
@@ -351,6 +365,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.4"
   pub_semver:
     dependency: transitive
     description:
@@ -358,6 +379,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  pub_updater:
+    dependency: transitive
+    description:
+      name: pub_updater
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.2"
   pubspec:
     dependency: transitive
     description:
@@ -595,7 +623,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.3.6"
   yaml:
     dependency: transitive
     description:
@@ -604,4 +632,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.14.4 <3.0.0"

--- a/sidekick/pubspec.yaml
+++ b/sidekick/pubspec.yaml
@@ -20,9 +20,9 @@ dependencies:
 
 dev_dependencies:
   lint: ^1.5.0
+  mason_cli: 0.1.0-dev.6
   test: ^1.17.0
   test_process: ^2.0.2
-  mason_cli: 0.1.0-dev.6
 
 executables:
   sidekick:

--- a/sidekick/pubspec.yaml
+++ b/sidekick/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   dartx: ^1.0.0
   dcli: ^1.16.2
   http: ^0.13.3
+
+  # Pin an old outdated version, the latest that works with Dart 2.14
   mason: 0.1.0-dev.4
   path: ^1.8.0
   sidekick_core: ^0.5.1
@@ -20,6 +22,7 @@ dev_dependencies:
   lint: ^1.5.0
   test: ^1.17.0
   test_process: ^2.0.2
+  mason_cli: 0.1.0-dev.6
 
 executables:
   sidekick:

--- a/sidekick/tool/generateTemplate.sh
+++ b/sidekick/tool/generateTemplate.sh
@@ -3,8 +3,8 @@ set -e
 
 echo "Generating Sidekick Template Bundle"
 rm -rf lib/src/templates/
-mason bundle cli_template/bricks/package -t dart -o lib/src/templates/
-mason bundle cli_template/bricks/entrypoint -t dart -o lib/src/templates/
+true | dart run tool/local_mason.dart bundle cli_template/bricks/package -t dart -o lib/src/templates/
+true | dart run tool/local_mason.dart bundle cli_template/bricks/entrypoint -t dart -o lib/src/templates/
 mv lib/src/templates/package_bundle.dart lib/src/templates/package_bundle.g.dart
 mv lib/src/templates/entrypoint_bundle.dart lib/src/templates/entrypoint_bundle.g.dart
 dart format lib/src/templates/*.g.dart

--- a/sidekick/tool/local_mason.dart
+++ b/sidekick/tool/local_mason.dart
@@ -1,0 +1,13 @@
+import 'package:mason_cli/src/command_runner.dart';
+
+/// Allows execution of the bundled mason version
+///
+/// Installing the mason CLI on the system doesn't produce a stable output.
+/// - mason has terrible versioning and doesn't follow semver
+/// - pub global activate pulls the latest dependencies. Due to breaking changes
+///   inside mason, using the latest dependencies doesn't work
+/// - pinning exact versions in the pubspec.yaml here is the only way to ensure
+///   it compiles forever
+Future<void> main(List<String> args) async {
+  await MasonCommandRunner().run(args);
+}

--- a/sidekick_core/lib/src/file_util.dart
+++ b/sidekick_core/lib/src/file_util.dart
@@ -49,6 +49,7 @@ extension FileModifier on File {
   void replaceAll(String text, String replacement) {
     String content = readAsStringSync();
     int index = 0;
+    // ignore: literal_only_boolean_expressions
     while (true) {
       index = content.indexOf(text, index);
       if (index == -1) {

--- a/sidekick_core/lib/src/repository.dart
+++ b/sidekick_core/lib/src/repository.dart
@@ -91,6 +91,7 @@ extension FindInDirectory on Directory {
   /// Returns `null` when reaching root (/) without a match
   Directory? findParent(bool Function(Directory dir) predicate) {
     var dir = this;
+    // ignore: literal_only_boolean_expressions
     while (true) {
       if (predicate(dir)) {
         return dir;


### PR DESCRIPTION
This allows us to use an old mason version that's still compatible with Dart 2.14

Installing the mason CLI on the system doesn't produce a stable output.
- mason has terrible versioning and doesn't follow semver
- pub global activate pulls the latest dependencies. Due to breaking changes inside mason, using the latest dependencies doesn't work (not even compile)
- pinning exact versions in the pubspec.yaml here is the only way to ensure it compiles forever

