### PR TITLE
Bump `sidekick_core` dependency

### DIFF
--- a/sidekick/pubspec.lock
+++ b/sidekick/pubspec.lock
@@ -469,7 +469,7 @@ packages:
       name: sidekick_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.2"
+    version: "0.6.0"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/sidekick/pubspec.yaml
+++ b/sidekick/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   mason: 0.1.0-dev.4
   path: ^1.8.0
   recase: ^4.0.0
-  sidekick_core: ^0.5.1
+  sidekick_core: ^0.6.0
 
 dev_dependencies:
   lint: ^1.5.0


### PR DESCRIPTION
- [x] Bump `sidekick_core` dependency so we can make use of `v0.6.0`