### PR TITLE
vault encrypt overwrites existing entry

### DIFF
--- a/sidekick_vault/lib/src/gpg.dart
+++ b/sidekick_vault/lib/src/gpg.dart
@@ -23,6 +23,10 @@ File gpgEncrypt(File file, String password, {File? output}) {
         return outDir.file(file.nameWithoutExtension);
       }();
 
+  if (outputFile.existsSync()) {
+    outputFile.deleteSync();
+  }
+
   startFromArgs('gpg', [
     '--symmetric',
     '--cipher-algo',

--- a/sidekick_vault/test/vault_command_test.dart
+++ b/sidekick_vault/test/vault_command_test.dart
@@ -202,4 +202,39 @@ void main() {
 
     expect(decryptedFile.readAsStringSync(), '42');
   });
+
+  test('encrypt overwrites existing files', () async {
+    final tempDir = Directory.systemTemp.createTempSync();
+    final clearTextFile = tempDir.file('cleartext.txt')
+      ..writeAsStringSync('Dash is cool');
+    addTearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    await withEnvironment(
+      () async {
+        await runner.run([
+          'vault',
+          'encrypt',
+          '--passphrase',
+          'dartlang',
+          '--vault-location',
+          'secret.txt.gpg',
+          clearTextFile.absolute.path,
+        ]);
+
+        // writing it a second time works just fine
+        await runner.run([
+          'vault',
+          'encrypt',
+          '--passphrase',
+          'dartlang',
+          '--vault-location',
+          'secret.txt.gpg',
+          clearTextFile.absolute.path,
+        ]);
+      },
+      environment: {'FLG_VAULT_PASSPHRASE': 'asdfasdf'},
+    );
+  });
 }


### PR DESCRIPTION
Before, `encrypt` crashed due to 

```
gpg: symmetric encryption of '/Users/pascalwelsch/Downloads/secret.txt' failed: File exists
```