### PR TITLE
Fix analysis error in command example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Writing your own commands is done in two steps.
     String get name => 'foo';
     
     @override
-    Future<void> run() {
+    Future<void> run() async {
       // your custom code here
     }
   }


### PR DESCRIPTION
Fixes an analysis error when copying and pasting the example complaining about the missing async.

<img width="1110" alt="image" src="https://user-images.githubusercontent.com/34774539/188965112-0df0e586-bf0b-4e54-be95-c2632a2b5d0e.png">
