### PR TITLE
Add CLI name validation

### DIFF
--- a/sidekick/lib/src/init/init_command.dart
+++ b/sidekick/lib/src/init/init_command.dart
@@ -51,20 +51,22 @@ class InitCommand extends Command {
       // fallback to cwd
       return cwd;
     }();
-    final cliName = (argResults!['cliName'] as String? ??
-            () {
-              print(
-                '${dcli.green('Please select a name for your sidekick CLI.')}\n'
-                'We know, selecting a name is hard. Here are some suggestions:',
-              );
-              final suggester = NameSuggester(projectDir: initDir);
-              final name = suggester.askUserForName();
-              if (name == null) {
-                throw 'No cliName provided. Call `sidekick init --cliName <your-name>`';
-              }
-              return name;
-            }())
-        .toLowerCase();
+    final cliName = argResults!['cliName'] as String? ??
+        () {
+          print(
+            '${dcli.green('Please select a name for your sidekick CLI.')}\n'
+            'We know, selecting a name is hard. Here are some suggestions:',
+          );
+          final suggester = NameSuggester(projectDir: initDir);
+          final name = suggester.askUserForName();
+          if (name == null) {
+            throw 'No cliName provided. Call `sidekick init --cliName <your-name>`';
+          }
+          return name;
+        }();
+    if (!isValidCliName(cliName)) {
+      throw invalidCliNameErrorMessage;
+    }
     print("Generating ${cliName}_sidekick");
 
     bool isGitDir(Directory dir) => dir.directory('.git').existsSync();

--- a/sidekick/lib/src/init/name_suggester.dart
+++ b/sidekick/lib/src/init/name_suggester.dart
@@ -110,4 +110,5 @@ const invalidCliNameErrorMessage = 'The CLI name must be valid: '
 
 bool isValidCliName(String name) => _cliNameRegExp.hasMatch(name);
 
+// See https://dart.dev/tools/pub/pubspec#name and https://github.com/dart-lang/sdk/blob/8d262e294400d2f7e41f05579c088a6409a7b2bb/pkg/dartdev/lib/src/utils.dart#L95
 final RegExp _cliNameRegExp = RegExp(r'^[a-z_][a-z\d_]*$');

--- a/sidekick/lib/src/init/name_suggester.dart
+++ b/sidekick/lib/src/init/name_suggester.dart
@@ -32,17 +32,24 @@ class NameSuggester {
       return null;
     }
     if (answer == names.last) {
-      return dcli.ask('Enter your CLI name').toLowerCase();
+      return dcli.ask(
+        'Enter your CLI name',
+        validator: const CliNameValidator(),
+      );
     } else {
-      return answer.toLowerCase();
+      return answer;
     }
   }
 
   /// Creates a list of acronyms based on the [projectDir] name
   Set<String> suggestCliNames() {
+    // valid cli names should not contain spaces or dashes
+    final normalizedName = p.normalize(
+      projectDir.absolute.path.replaceAll('-', '_').replaceAll(' ', '_'),
+    );
     // reverse to make accessing of the elements easier
     final parts = p
-        .split(p.normalize(projectDir.absolute.path))
+        .split(normalizedName)
         .where((element) => element.isNotEmpty)
         .toList()
         .reversed
@@ -53,25 +60,54 @@ class NameSuggester {
     }
     final Set<String> suggestions = {};
 
-    final dirName = parts[0];
-    suggestions.add(dirName.toAcronym());
-    suggestions.add(dirName.toAcronym(splitSyllables: true));
-    if (parts.length >= 2) {
-      // include parent dir
-      final parentDirName = parts[1];
-      final name = '$parentDirName/$dirName';
-      suggestions.add(name.toAcronym());
-      suggestions.add(name.toAcronym(splitSyllables: true));
-    }
+    try {
+      final dirName = parts[0];
+      suggestions.add(dirName.toAcronym());
+      suggestions.add(dirName.toAcronym(splitSyllables: true));
+      if (parts.length >= 2) {
+        // include parent dir
+        final parentDirName = parts[1];
+        final name = '$parentDirName/$dirName';
+        suggestions.add(name.toAcronym());
+        suggestions.add(name.toAcronym(splitSyllables: true));
+      }
 
-    // first last character variant
-    final chars = dirName.characters.where((it) => it.isAscii);
-    if (chars.length >= 2) {
-      suggestions.add('${chars.first}${chars.last}');
+      // first last character variant
+      final chars = dirName.characters.where((it) => it.isAscii);
+      if (chars.length >= 2) {
+        suggestions.add('${chars.first}${chars.last}');
+      }
+    } catch (_) {
+      // `toAcronym` throws an ArgumentError if the input only contains
+      // punctuation symbols. However, '_' is a valid dart package name.
     }
 
     // TODO acronym should return the filtered syllableWords. We could suggest all of them on their own
 
-    return suggestions;
+    return suggestions
+        .map((e) => e.toLowerCase())
+        .where(isValidCliName)
+        .toSet();
   }
 }
+
+class CliNameValidator extends dcli.AskValidator {
+  const CliNameValidator();
+
+  @override
+  String validate(String line) {
+    if (!isValidCliName(line)) {
+      throw dcli.AskValidatorException(dcli.red(invalidCliNameErrorMessage));
+    }
+
+    return line;
+  }
+}
+
+const invalidCliNameErrorMessage = 'The CLI name must be valid: '
+    'at least one lower case letter or underscore '
+    'followed by zero or more lower case letters, digits, or underscores.';
+
+bool isValidCliName(String name) => _cliNameRegExp.hasMatch(name);
+
+final RegExp _cliNameRegExp = RegExp(r'^[a-z_][a-z\d_]*$');

--- a/sidekick/test/init_test.dart
+++ b/sidekick/test/init_test.dart
@@ -1,3 +1,4 @@
+import 'package:sidekick/src/init/name_suggester.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
@@ -38,6 +39,24 @@ void main() {
         dashProcess.shouldExit(0);
       },
       timeout: const Timeout(Duration(minutes: 5)),
+    );
+
+    test(
+      'throws error when cli name is invalid',
+      () async {
+        final projectRoot =
+            setupTemplateProject('test/templates/minimal_dart_package');
+        final process = await sidekickCli(
+          ['init', '-n', '-42invalidName'],
+          workingDirectory: projectRoot,
+        );
+
+        await process.shouldExit(255);
+        expect(
+          await process.stderr.rest.contains(invalidCliNameErrorMessage),
+          isTrue,
+        );
+      },
     );
   });
 


### PR DESCRIPTION
Added validation of CLI name to prevent some errors.

I used the same validation as dart (See https://dart.dev/tools/pub/pubspec#name and https://github.com/dart-lang/sdk/blob/8d262e294400d2f7e41f05579c088a6409a7b2bb/pkg/dartdev/lib/src/utils.dart#L95)
 

## Fixed errors
<details>
<summary> `sidekick init` crashes in directory named `_` (which actually is a valid dart package identifier) </summary>

```
❯ dart create _
Creating _ using template console...
...

Created project _ in _! In order to get started, run the following commands:
...

❯ cd _
❯ sidekick init
Welcome to sidekick. You're about to initialize a sidekick project

Please select a name for your sidekick CLI.
We know, selecting a name is hard. Here are some suggestions:
Unhandled exception:
Invalid argument(s): String contained no letters. Cannot create acronym. String: _
#0      generateAcronym (package:acronym/src/acronym_base.dart:25:5)
#1      AcronymString.toAcronym (package:acronym/src/extensions.dart:30:12)
#2      NameSuggester.suggestCliNames (package:sidekick/src/init/name_suggester.dart:57:29)
#3      NameSuggester.askUserForName (package:sidekick/src/init/name_suggester.dart:18:25)
#4      InitCommand.run.<anonymous closure> (package:sidekick/src/init/init_command.dart:61:38)
#5      InitCommand.run (package:sidekick/src/init/init_command.dart:66:14)
#6      CommandRunner.runCommand (package:args/command_runner.dart:209:27)
#7      CommandRunner.run.<anonymous closure> (package:args/command_runner.dart:119:25)
#8      new Future.sync (dart:async/future.dart:302:31)
#9      CommandRunner.run (package:args/command_runner.dart:119:14)
#10     main (package:sidekick/sidekick.dart:6:16)
#11     main (file:///Users/pepe/.pub-cache/hosted/pub.dartlang.org/sidekick-0.6.0/bin/sidekick.dart:4:18)
#12     _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:295:32)
#13     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192:12)

```
</details>

<details>
<summary> `sidekick init` suggests empty package name in directory with dashes </summary>

```
❯ dart create a-b-c
Creating a_b_c using template console...
...

Created project a_b_c in a-b-c! In order to get started, run the following commands:
...

❯ cd a-b-c
❯ sidekick init
Welcome to sidekick. You're about to initialize a sidekick project

Please select a name for your sidekick CLI.
We know, selecting a name is hard. Here are some suggestions:
  1) 
  2) s
  3) sp
  4) ac
  5) Enter your own
Type the number of the fitting acronym or choose Enter your own 1
Unhandled exception:
No cliName provided. Call `sidekick init --cliName <your-name>`
#0      InitCommand.run.<anonymous closure> (package:sidekick/src/init/init_command.dart:63:17)
#1      InitCommand.run (package:sidekick/src/init/init_command.dart:66:14)
#2      CommandRunner.runCommand (package:args/command_runner.dart:209:27)
#3      CommandRunner.run.<anonymous closure> (package:args/command_runner.dart:119:25)
#4      new Future.sync (dart:async/future.dart:302:31)
#5      CommandRunner.run (package:args/command_runner.dart:119:14)
#6      main (package:sidekick/sidekick.dart:6:16)
#7      main (file:///Users/pepe/.pub-cache/hosted/pub.dartlang.org/sidekick-0.6.0/bin/sidekick.dart:4:18)
#8      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:295:32)
#9      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192:12)


```
</details>


<details>
<summary>CLI name starting with `_` crashes on start</summary>

```
❯ sidekick init
Welcome to sidekick. You're about to initialize a sidekick project

...
Enter your CLI name _foo
Generating _foo_sidekick
...
❯ ./_foo
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LC_ALL = (unset),
        LC_CTYPE = "en_DE.UTF-8",
        LANG = (unset)
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
cat: /Users/pepe/dev/repos/samples/sample/packages/_foo_sidekick/build/cli.stamp: No such file or directory
Installing _foo command line application...
- Getting dependencies
Resolving dependencies... (1.1s)
  basic_utils 3.9.4 (5.3.0 available)
  circular_buffer 0.10.0 (0.11.0 available)
  dcli 1.16.3 (1.34.0 available)
  dcli_core 0.0.7 (1.34.0 available)
  ffi 1.2.1 (2.0.1 available)
  posix 3.1.0 (4.0.0 available)
  settings_yaml 3.3.1 (4.0.0 available)
  win32 2.6.1 (3.0.0 available)
✔ Getting dependencies
- Bundling assets
✔ Bundling assets
- Compiling sidekick cli
Info: Compiling with sound null safety
lib/src/commands/deps_command.dart:15:16: Error: The getter '_fooProject' isn't defined for the class 'DepsCommand'.
 - 'DepsCommand' is from 'package:_foo_sidekick/src/commands/deps_command.dart' ('lib/src/commands/deps_command.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named '_fooProject'.
      allowed: _fooProject.allPackages.map((it) => it.name),
               ^^^^^^^^^^^
lib/src/commands/deps_command.dart:30:27: Error: The getter '_fooProject' isn't defined for the class 'DepsCommand'.
 - 'DepsCommand' is from 'package:_foo_sidekick/src/commands/deps_command.dart' ('lib/src/commands/deps_command.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named '_fooProject'.
    for (final package in _fooProject.allPackages) {
                          ^^^^^^^^^^^
lib/src/commands/deps_command.dart:37:21: Error: The getter '_fooProject' isn't defined for the class 'DepsCommand'.
 - 'DepsCommand' is from 'package:_foo_sidekick/src/commands/deps_command.dart' ('lib/src/commands/deps_command.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named '_fooProject'.
    final package = _fooProject.allPackages.firstOrNullWhere((it) => it.name == name);
                    ^^^^^^^^^^^
lib/src/commands/deps_command.dart:39:30: Error: The getter '_fooProject' isn't defined for the class 'DepsCommand'.
 - 'DepsCommand' is from 'package:_foo_sidekick/src/commands/deps_command.dart' ('lib/src/commands/deps_command.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named '_fooProject'.
      final packageOptions = _fooProject.allPackages.map((it) => it.name).toList(growable: false);
                             ^^^^^^^^^^^
lib/src/commands/recompile_command.dart:17:27: Error: The getter '_fooProject' isn't defined for the class 'RecompileCommand'.
 - 'RecompileCommand' is from 'package:_foo_sidekick/src/commands/recompile_command.dart' ('lib/src/commands/recompile_command.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named '_fooProject'.
    final installScript = _fooProject.root.file('packages/_foo_sidekick/tool/install.sh');
                          ^^^^^^^^^^^
Error: AOT compilation failed
Generating AOT kernel dill failed!

```
</details>