### PR TITLE
[core] Allow packages without lib folder

### DIFF
--- a/sidekick_core/lib/src/dart_package.dart
+++ b/sidekick_core/lib/src/dart_package.dart
@@ -16,14 +16,6 @@ class DartPackage {
     if (!pubspec.existsSync()) {
       return null;
     }
-    final lib = normalizedDir.directory('lib');
-    if (!lib.existsSync()) {
-      printerr(
-        'Detected a pubspec.yaml in ${normalizedDir.absolute.path} but the /lib directory is missing. '
-        'The directory will not be interpreted as valid Dart package.',
-      );
-      return null;
-    }
     final pubspecYamlContent = pubspec.readAsStringSync();
     try {
       // Check for valid package name

--- a/sidekick_core/lib/src/dart_package.dart
+++ b/sidekick_core/lib/src/dart_package.dart
@@ -7,7 +7,6 @@ class DartPackage {
 
   /// Returns [DartPackage] if a directory fulfils the requirements of a Dart/Flutter package
   /// - pubspec.yaml
-  /// - lib directory
   /// - name in pubspec.yaml
   /// (- flutter dependency)
   static DartPackage? fromDirectory(Directory directory) {


### PR DESCRIPTION
Our very own sidekick plugin system allows packages without lib folder. While most packages do have a lib folder, it's not a requirement and it's completely fine not to have a lib folder


> At a minimum, a Dart package is a directory containing a [pubspec file](https://dart.dev/tools/pub/pubspec). The pubspec contains some metadata about the package. Additionally, a package can contain dependencies (listed in the pubspec), Dart libraries, apps, resources, tests, images, and examples.

[src](https://dart.dev/guides/packages)