### PR TITLE
Create PluginContext

### DIFF
--- a/sidekick_core/lib/src/commands/plugins/create_templates/install_only.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/install_only.dart
@@ -47,9 +47,8 @@ import 'package:sidekick_core/sidekick_core.dart'
     hide cliName, repository, mainProject;
 import 'package:sidekick_plugin_installer/sidekick_plugin_installer.dart';
 
-Future<void> main(List<String> args) async {
-  // The installer injects the path to the sidekick project as first argument
-  final package = SidekickPackage.fromDirectory(Directory(args[0]))!;
+Future<void> main() async {
+  final SidekickPackage package = PluginContext.sidekickPackage;
 
   final commandFile = package.root.file('lib/src/${pluginName.snakeCase}.dart');
   commandFile.writeAsStringSync("""

--- a/sidekick_core/lib/src/commands/plugins/create_templates/install_only.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/install_only.dart
@@ -37,9 +37,10 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
+  sidekick_core: '>=0.7.1 <1.0.0'
 
 dev_dependencies:
-  sidekick_plugin_installer:
+  sidekick_plugin_installer: ^0.1.3
 ''';
 
   String get installTemplate => '''

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
@@ -39,9 +39,10 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
+  sidekick_core: '>=0.7.1 <1.0.0'
 
 dev_dependencies:
-  sidekick_plugin_installer:
+  sidekick_plugin_installer: ^0.1.3
 ''';
 
   String get installTemplate => '''

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
@@ -49,23 +49,22 @@ import 'package:sidekick_core/sidekick_core.dart'
     hide cliName, repository, mainProject;
 import 'package:sidekick_plugin_installer/sidekick_plugin_installer.dart';
 
-Future<void> main(List<String> args) async {
-  // The installer injects the path to the sidekick project as first argument
-  final package = SidekickPackage.fromDirectory(Directory(args[0]))!;
-  
+Future<void> main() async {
+  final SidekickPackage package = PluginContext.sidekickPackage;
+
+  if (PluginContext.localPlugin == null) {
+    pubAddDependency(package, 'sidekick_flutter');
+  } else {
+    // For local development
+    pubAddLocalDependency(package, PluginContext.localPlugin!.root.path);
+  }
+  pubGet(package);
   
   final commandFile = package.root.file('lib/src/${pluginName.snakeCase}.dart');
   commandFile.writeAsStringSync("""
 $exampleCommand
 """);
   
-  // If your plugin is hosted on pub.dev, use this line
-  // pubAddDependency(package, '$pluginName');
-  // For local development, use this line instead
-  pubAddLocalDependency(package, env['SIDEKICK_LOCAL_PLUGIN_PATH']!);
-  
-  pubGet(package);
-
   registerPlugin(
     sidekickCli: package,
     import: "import 'package:\${package.name}/src/${pluginName.snakeCase}.dart';",

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
@@ -38,9 +38,10 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
+  sidekick_core: '>=0.7.1 <1.0.0'
 
 dev_dependencies:
-  sidekick_plugin_installer:
+  sidekick_plugin_installer: ^0.1.3
 ''';
 
   String get installTemplate => '''

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
@@ -48,15 +48,15 @@ import 'package:sidekick_core/sidekick_core.dart'
     hide cliName, repository, mainProject;
 import 'package:sidekick_plugin_installer/sidekick_plugin_installer.dart';
 
-Future<void> main(List<String> args) async {
-  // The installer injects the path to the sidekick project as first argument
-  final package = SidekickPackage.fromDirectory(Directory(args[0]))!;
-  
-  // If your plugin is hosted on pub.dev, use this line
-  // pubAddDependency(package, '$pluginName');
-  // For local development, use this line instead
-  pubAddLocalDependency(package, env['SIDEKICK_LOCAL_PLUGIN_PATH']!);
-  
+Future<void> main() async {
+  final SidekickPackage package = PluginContext.sidekickPackage;
+
+  if (PluginContext.localPlugin == null) {
+    pubAddDependency(package, 'sidekick_flutter');
+  } else {
+    // For local development
+    pubAddLocalDependency(package, PluginContext.localPlugin!.root.path);
+  }
   pubGet(package);
 
   registerPlugin(

--- a/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
@@ -112,7 +112,7 @@ class InstallPluginCommand extends Command {
       );
     }
     sidekickDartRuntime.dart(
-      [installScript.path, target.root.path],
+      [installScript.path],
       workingDirectory: target.root,
     );
 
@@ -207,6 +207,7 @@ Directory _getPackageRootDirForHostedOrGitSource(ArgResults args) {
   final packageName = activationInfo.group(1)!;
   final packageVersion = activationInfo.group(2)!;
 
+  // TODO Don't deactivate when the package was already activated
   // The package was only activated to cache it and can be deactivated now
   sidekickDartRuntime.dart(
     [

--- a/sidekick_plugin_installer/lib/sidekick_plugin_installer.dart
+++ b/sidekick_plugin_installer/lib/sidekick_plugin_installer.dart
@@ -1,6 +1,7 @@
 library sidekick_plugin_installer;
 
 export 'package:sidekick_plugin_installer/src/add_import.dart';
+export 'package:sidekick_plugin_installer/src/plugin_context.dart';
 export 'package:sidekick_plugin_installer/src/pub_add_dependency.dart';
 export 'package:sidekick_plugin_installer/src/pub_add_local_dependency.dart';
 export 'package:sidekick_plugin_installer/src/pub_get.dart';

--- a/sidekick_plugin_installer/lib/src/plugin_context.dart
+++ b/sidekick_plugin_installer/lib/src/plugin_context.dart
@@ -32,7 +32,7 @@ class PluginContext {
   /// to link the plugin dependency to a local path, instead of pub.dev where
   /// the plugin is not yet published. (See [pubAddLocalDependency])
   ///
-  /// Returns `null` when the plugin is not installed form local source, but
+  /// Returns `null` when the plugin is not installed from local source, but
   /// from a remote source (pub or git)
   static DartPackage? get localPlugin {
     if (_localPlugin == null) {

--- a/sidekick_plugin_installer/lib/src/plugin_context.dart
+++ b/sidekick_plugin_installer/lib/src/plugin_context.dart
@@ -1,0 +1,56 @@
+// ignore_for_file: avoid_classes_with_only_static_members
+
+import 'package:sidekick_core/sidekick_core.dart';
+import 'package:sidekick_plugin_installer/sidekick_plugin_installer.dart';
+
+/// Global parameters passed from sidekick into the plugin installer
+class PluginContext {
+  /// The sidekick cli package the plugin is going to be installed into
+  static SidekickPackage get sidekickPackage {
+    if (_sidekickPackage == null) {
+      final home = env['SIDEKICK_PACKAGE_HOME'];
+      if (home == null) {
+        throw "env.SIDEKICK_PACKAGE_HOME is not set";
+      }
+      final dir = Directory(home);
+      if (!dir.existsSync()) {
+        throw "Directory at ${dir.absolute.path} (env.SIDEKICK_PACKAGE_HOME) does not exist";
+      }
+      _sidekickPackage = SidekickPackage.fromDirectory(Directory(home));
+      if (_sidekickPackage == null) {
+        throw "Directory at ${dir.absolute.path} (env.SIDEKICK_PACKAGE_HOME) is not a dart package";
+      }
+    }
+    return _sidekickPackage!;
+  }
+
+  static SidekickPackage? _sidekickPackage;
+
+  /// This is the plugin package that is getting installed from local source
+  ///
+  /// Plugin installer might need to know the local location during development,
+  /// to link the plugin dependency to a local path, instead of pub.dev where
+  /// the plugin is not yet published. (See [pubAddLocalDependency])
+  ///
+  /// Returns `null` when the plugin is not installed form local source, but
+  /// from a remote source (pub or git)
+  static DartPackage? get localPlugin {
+    if (_localPlugin == null) {
+      final path = env['SIDEKICK_LOCAL_PLUGIN_PATH'];
+      if (path == null) {
+        return null;
+      }
+      final dir = Directory(path);
+      if (!dir.existsSync()) {
+        throw "Directory at ${dir.absolute.path} (env.SIDEKICK_LOCAL_PLUGIN_PATH) does not exist";
+      }
+      _localPlugin = DartPackage.fromDirectory(dir);
+      if (_localPlugin == null) {
+        throw "Directory at ${dir.absolute.path} (env.SIDEKICK_LOCAL_PLUGIN_PATH) is not a dart package";
+      }
+    }
+    return _localPlugin;
+  }
+
+  static DartPackage? _localPlugin;
+}


### PR DESCRIPTION
Inject all information for installers via `PluginContext`.

This makes the `pubAddLocalDependency` workaround much more pleasant, no more code in comments 

Also fixes #67 
