### PR TITLE
Allow setting flutterSdkPath and dartSdkPath for the flutter and dart commands

### DIFF
--- a/sidekick_core/lib/sidekick_core.dart
+++ b/sidekick_core/lib/sidekick_core.dart
@@ -195,6 +195,5 @@ Directory? get dartSdk {
       'outside of a Command executed with SidekickCommandRunner.',
     );
   }
-  return _activeRunner?.dartSdk ??
-      _activeRunner?.flutterSdk?.directory('bin/cache/dart-sdk');
+  return _activeRunner?.dartSdk;
 }

--- a/sidekick_core/lib/sidekick_core.dart
+++ b/sidekick_core/lib/sidekick_core.dart
@@ -41,6 +41,8 @@ SidekickCommandRunner initializeSidekick({
   required String name,
   String? description,
   String? mainProjectPath,
+  String? flutterSdkPath,
+  String? dartSdkPath,
 }) {
   DartPackage? mainProject;
 
@@ -70,11 +72,15 @@ class SidekickCommandRunner<T> extends CommandRunner<T> {
     required this.repository,
     this.mainProject,
     required this.workingDirectory,
+    this.flutterSdk,
+    this.dartSdk,
   }) : super(cliName, description);
 
   final Repository repository;
   final DartPackage? mainProject;
   final Directory workingDirectory;
+  final Directory? flutterSdk;
+  final Directory? dartSdk;
 
   /// Mounts the sidekick related globals, returns a function to unmount them
   /// and restore the previous globals
@@ -148,4 +154,33 @@ DartPackage? get mainProject {
     );
   }
   return _activeRunner?.mainProject;
+}
+
+/// Returns the path to he Flutter SDK sidekick should use for the [flutter] command
+///
+/// This variable is usually set to a pinned version of the Flutter SDK per project, i.e.
+/// - https://github.com/passsy/flutter_wrapper
+/// - https://github.com/fluttertools/fvm
+Directory? get flutterSdk {
+  if (_activeRunner == null) {
+    error(
+      'You cannot access flutterSdk '
+      'outside of a Command executed with SidekickCommandRunner.',
+    );
+  }
+  return _activeRunner?.flutterSdk;
+}
+
+/// Returns the path to the Dart SDK sidekick should use for the [dart] command
+///
+/// Usually inherited from [flutterSdk] which ships with an embedded Dart SDK
+Directory? get dartSdk {
+  if (_activeRunner == null) {
+    error(
+      'You cannot access dartSdk '
+      'outside of a Command executed with SidekickCommandRunner.',
+    );
+  }
+  return _activeRunner?.dartSdk ??
+      _activeRunner?.flutterSdk?.directory('bin/cache/dart-sdk');
 }

--- a/sidekick_core/lib/sidekick_core.dart
+++ b/sidekick_core/lib/sidekick_core.dart
@@ -24,6 +24,7 @@ export 'package:sidekick_core/src/dart.dart';
 export 'package:sidekick_core/src/dart_package.dart';
 export 'package:sidekick_core/src/dart_runtime.dart';
 export 'package:sidekick_core/src/file_util.dart';
+export 'package:sidekick_core/src/flutter.dart';
 export 'package:sidekick_core/src/flutterw.dart';
 export 'package:sidekick_core/src/forward_command.dart';
 export 'package:sidekick_core/src/git.dart';
@@ -34,9 +35,17 @@ export 'package:sidekick_core/src/sidekick_package.dart';
 ///
 /// Set [name] to the name of your CLI entrypoint
 ///
-/// [mainProjectPath], when set, links to the main package. For a flutter apps
-/// it is the package that actually builds the flutter app.
-/// Set [mainProjectPath] relative to the git repository root
+/// [mainProjectPath] should be set when you have a package that you
+/// consider the main package of the whole repository.
+/// When your repository contains only one Flutter package in root set
+/// `mainProjectPath = '.'`.
+/// In a multi package repository you might use the same when the main package
+/// is in root, or `mainProjectPath = 'packages/my_app'` when it is in a subfolder.
+///
+/// Set [flutterSdkPath] when you bind a flutter sdk to this project. This SDK
+/// enables the [flutter] and [dart] commands.
+/// [dartSdkPath] is inherited from [flutterSdkPath]. Set it only for pure dart
+/// projects.
 SidekickCommandRunner initializeSidekick({
   required String name,
   String? description,
@@ -59,6 +68,8 @@ SidekickCommandRunner initializeSidekick({
     repository: repo,
     mainProject: mainProject,
     workingDirectory: Directory.current,
+    flutterSdk: flutterSdkPath == null ? null : Directory(flutterSdkPath),
+    dartSdk: dartSdkPath == null ? null : Directory(dartSdkPath),
   );
   return runner;
 }
@@ -97,6 +108,9 @@ class SidekickCommandRunner<T> extends CommandRunner<T> {
 
   @override
   Future<T?> run(Iterable<String> args) async {
+    // a new command gets executes, reset whatever exitCode the previous command has set
+    exitCode = 0;
+
     final unmount = mount();
     final result = await super.run(args);
     unmount();

--- a/sidekick_core/lib/src/commands/dart_command.dart
+++ b/sidekick_core/lib/src/commands/dart_command.dart
@@ -12,7 +12,6 @@ class DartCommand extends ForwardCommand {
 
   @override
   Future<void> run() async {
-    final exitCode = dart(argResults!.arguments);
-    exit(exitCode);
+    exitCode = dart(argResults!.arguments);
   }
 }

--- a/sidekick_core/lib/src/commands/flutter_command.dart
+++ b/sidekick_core/lib/src/commands/flutter_command.dart
@@ -14,6 +14,20 @@ class FlutterCommand extends ForwardCommand {
 
   @override
   Future<void> run() async {
-    exitCode = flutter(argResults!.arguments);
+    final args = argResults!.arguments;
+    try {
+      exitCode = flutter(args);
+    } on FlutterSdkNotSetException catch (original) {
+      // for backwards compatibility link to the previous required flutter_wrapper location
+      try {
+        exitCode = flutterw(args);
+        printerr("Sidekick Warning: ${original.message}");
+        // success with flutterw, immediately return
+        return;
+      } on FlutterWrapperNotFoundException catch (_) {
+        // rethrow original below
+      }
+      rethrow /* original */;
+    }
   }
 }

--- a/sidekick_core/lib/src/commands/flutter_command.dart
+++ b/sidekick_core/lib/src/commands/flutter_command.dart
@@ -14,15 +14,6 @@ class FlutterCommand extends ForwardCommand {
 
   @override
   Future<void> run() async {
-    // TODO find pinned fvm flutter version
-    try {
-      final exitCode = flutterw(argResults!.arguments);
-      exit(exitCode);
-    } on FlutterWrapperNotFoundException catch (_) {
-      printerr(
-        'Could not find a pinned flutter version associated with the project.\n'
-        'Please install https://github.com/passsy/flutter_wrapper, to pin a flutter version',
-      );
-    }
+    exitCode = flutter(argResults!.arguments);
   }
 }

--- a/sidekick_core/lib/src/commands/flutter_command.dart
+++ b/sidekick_core/lib/src/commands/flutter_command.dart
@@ -20,6 +20,7 @@ class FlutterCommand extends ForwardCommand {
     } on FlutterSdkNotSetException catch (original) {
       // for backwards compatibility link to the previous required flutter_wrapper location
       try {
+        // ignore: deprecated_member_use_from_same_package
         exitCode = flutterw(args);
         printerr("Sidekick Warning: ${original.message}");
         // success with flutterw, immediately return

--- a/sidekick_core/lib/src/dart.dart
+++ b/sidekick_core/lib/src/dart.dart
@@ -34,6 +34,7 @@ int dart(
         if (!embeddedSdk.existsSync()) {
           // Flutter SDK is not fully initialized, the Dart SDK not yet downloaded
           // Execute flutter_tool to download the embedded dart runtime
+          // ignore: deprecated_member_use_from_same_package
           flutterw([], workingDirectory: workingDirectory);
         }
         if (embeddedSdk.existsSync()) {

--- a/sidekick_core/lib/src/dart.dart
+++ b/sidekick_core/lib/src/dart.dart
@@ -10,21 +10,19 @@ int dart(
   Directory? workingDirectory,
   dcli.Progress? progress,
 }) {
-  // TODO find pinned fvm flutter version
-  final binDir = repository.root.directory('.flutter/bin/cache/dart-sdk/bin/');
+  final sdk = dartSdk;
+  if (sdk == null) {
+    throw DartSdkNotSetException();
+  }
+
   final dart = () {
     if (Platform.isWindows) {
-      return binDir.file('dart.exe');
+      return sdk.file('bin/dart.exe');
     } else {
-      return binDir.file('dart');
+      return sdk.file('bin/dart');
     }
   }();
 
-  if (!dart.existsSync()) {
-    // run a flutterw command forcing flutter_tool to download the dart sdk
-    print("running flutterw to download dart");
-    flutterw([], workingDirectory: mainProject!.root);
-  }
   final process = dcli.startFromArgs(
     dart.path,
     args,
@@ -35,3 +33,6 @@ int dart(
   );
   return process.exitCode ?? -1;
 }
+
+/// The Dart SDK path is not set in [initializeSidekick] (param [dartSdk])
+class DartSdkNotSetException implements Exception {}

--- a/sidekick_core/lib/src/dart.dart
+++ b/sidekick_core/lib/src/dart.dart
@@ -10,16 +10,29 @@ int dart(
   Directory? workingDirectory,
   dcli.Progress? progress,
 }) {
-  final sdk = dartSdk;
+  Directory? sdk = dartSdk;
+  if (sdk == null) {
+    if (flutterSdk != null) {
+      final embeddedSdk = flutterSdk!.directory('bin/cache/dart-sdk');
+      if (!embeddedSdk.existsSync()) {
+        // Flutter SDK is not fully initialized, the Dart SDK not yet downloaded
+        // Execute flutter_tool to download the embedded dart runtime
+        flutter([], workingDirectory: workingDirectory);
+      }
+      if (embeddedSdk.existsSync()) {
+        sdk = embeddedSdk;
+      }
+    }
+  }
   if (sdk == null) {
     throw DartSdkNotSetException();
   }
 
   final dart = () {
     if (Platform.isWindows) {
-      return sdk.file('bin/dart.exe');
+      return sdk!.file('bin/dart.exe');
     } else {
-      return sdk.file('bin/dart');
+      return sdk!.file('bin/dart');
     }
   }();
 

--- a/sidekick_core/lib/src/dart.dart
+++ b/sidekick_core/lib/src/dart.dart
@@ -35,4 +35,9 @@ int dart(
 }
 
 /// The Dart SDK path is not set in [initializeSidekick] (param [dartSdk])
-class DartSdkNotSetException implements Exception {}
+class DartSdkNotSetException implements Exception {
+  @override
+  String toString() {
+    return "DartSdkNotSetException{message: No Dart SDK set. Please set it in `initializeSidekick(dartSdkPath: 'path/to/sdk')`}.";
+  }
+}

--- a/sidekick_core/lib/src/flutter.dart
+++ b/sidekick_core/lib/src/flutter.dart
@@ -15,17 +15,10 @@ int flutter(
     throw FlutterSdkNotSetException();
   }
 
-  final flutter = () {
-    if (Platform.isWindows) {
-      return sdk.file('bin/flutter.exe');
-    }
-    return sdk.file('bin/flutter');
-  }();
-
   if (Platform.isWindows) {
     final process = dcli.startFromArgs(
       'bash',
-      [flutter.path, ...args],
+      [sdk.file('bin/flutter.exe').path, ...args],
       workingDirectory: workingDir.path,
       nothrow: true,
       progress: progress,
@@ -34,7 +27,7 @@ int flutter(
     return process.exitCode ?? -1;
   } else {
     final process = dcli.startFromArgs(
-      flutter.path,
+      sdk.file('bin/flutter').path,
       args,
       workingDirectory: workingDir.path,
       nothrow: true,

--- a/sidekick_core/lib/src/flutter.dart
+++ b/sidekick_core/lib/src/flutter.dart
@@ -46,4 +46,9 @@ int flutter(
 }
 
 /// The Flutter SDK path is not set in [initializeSidekick] (param [flutterSdk])
-class FlutterSdkNotSetException implements Exception {}
+class FlutterSdkNotSetException implements Exception {
+  @override
+  String toString() {
+    return "FlutterSdkNotSetException{message: No Flutter SDK set. Please set it in `initializeSidekick(flutterSdkPath: 'path/to/sdk')`}";
+  }
+}

--- a/sidekick_core/lib/src/flutter.dart
+++ b/sidekick_core/lib/src/flutter.dart
@@ -1,0 +1,49 @@
+import 'package:dcli/dcli.dart' as dcli;
+import 'package:sidekick_core/sidekick_core.dart';
+
+/// Executes Flutter command from Flutter SDK set in [flutterSdk]
+int flutter(
+  List<String> args, {
+  Directory? workingDirectory,
+  dcli.Progress? progress,
+}) {
+  final workingDir =
+      workingDirectory?.absolute ?? entryWorkingDirectory.absolute;
+
+  final sdk = flutterSdk;
+  if (sdk == null) {
+    throw FlutterSdkNotSetException();
+  }
+
+  final flutter = () {
+    if (Platform.isWindows) {
+      return sdk.file('bin/flutter.exe');
+    }
+    return sdk.file('bin/flutter');
+  }();
+
+  if (Platform.isWindows) {
+    final process = dcli.startFromArgs(
+      'bash',
+      [flutter.path, ...args],
+      workingDirectory: workingDir.path,
+      nothrow: true,
+      progress: progress,
+      terminal: progress == null,
+    );
+    return process.exitCode ?? -1;
+  } else {
+    final process = dcli.startFromArgs(
+      flutter.path,
+      args,
+      workingDirectory: workingDir.path,
+      nothrow: true,
+      progress: progress,
+      terminal: progress == null,
+    );
+    return process.exitCode ?? -1;
+  }
+}
+
+/// The Flutter SDK path is not set in [initializeSidekick] (param [flutterSdk])
+class FlutterSdkNotSetException implements Exception {}

--- a/sidekick_core/lib/src/flutter.dart
+++ b/sidekick_core/lib/src/flutter.dart
@@ -40,8 +40,10 @@ int flutter(
 
 /// The Flutter SDK path is not set in [initializeSidekick] (param [flutterSdk])
 class FlutterSdkNotSetException implements Exception {
+  final String message =
+      "No Flutter SDK set. Please set it in `initializeSidekick(flutterSdkPath: 'path/to/sdk')`";
   @override
   String toString() {
-    return "FlutterSdkNotSetException{message: No Flutter SDK set. Please set it in `initializeSidekick(flutterSdkPath: 'path/to/sdk')`}";
+    return "FlutterSdkNotSetException{message: $message}";
   }
 }

--- a/sidekick_core/lib/src/flutterw.dart
+++ b/sidekick_core/lib/src/flutterw.dart
@@ -1,6 +1,16 @@
 import 'package:dcli/dcli.dart' as dcli;
 import 'package:sidekick_core/sidekick_core.dart';
 
+/// Returns the closes `flutterw` file, searching upwards from [mainProject] or [Repository.cliPackageDir] or [repository]
+File? findFlutterwLocation() {
+  final searchStart =
+      mainProject?.root ?? Repository.cliPackageDir ?? repository.root;
+  final flutterwParent =
+      searchStart.findParent((dir) => dir.file('flutterw').existsSync());
+  final flutterw = flutterwParent?.file('flutterw');
+  return flutterw;
+}
+
 /// Executes Flutter CLI (flutter_tool) via flutter_wrapper
 ///
 /// https://github.com/passsy/flutter_wrapper
@@ -10,17 +20,10 @@ int flutterw(
   Directory? workingDirectory,
   dcli.Progress? progress,
 }) {
-  // find closest flutterw
-  final searchStart =
-      mainProject?.root ?? Repository.cliPackageDir ?? repository.root;
-  final flutterwParent =
-      searchStart.findParent((dir) => dir.file('flutterw').existsSync());
-  final flutterw = flutterwParent?.file('flutterw');
-
-  if (flutterw == null || !flutterw.existsSync()) {
+  final flutterw = findFlutterwLocation();
+  if (flutterw == null) {
     throw FlutterWrapperNotFoundException();
   }
-
   final workingDir =
       workingDirectory?.absolute ?? entryWorkingDirectory.absolute;
 

--- a/sidekick_core/lib/src/flutterw.dart
+++ b/sidekick_core/lib/src/flutterw.dart
@@ -4,6 +4,7 @@ import 'package:sidekick_core/sidekick_core.dart';
 /// Executes Flutter CLI (flutter_tool) via flutter_wrapper
 ///
 /// https://github.com/passsy/flutter_wrapper
+@Deprecated('Use flutter() instead')
 int flutterw(
   List<String> args, {
   Directory? workingDirectory,

--- a/sidekick_core/test/dart_command_test.dart
+++ b/sidekick_core/test/dart_command_test.dart
@@ -71,5 +71,17 @@ Directory? systemFlutterSdkPath() {
 }
 
 Directory? systemDartSdkPath() {
-  return systemFlutterSdkPath()?.directory('bin/cache/dart-sdk');
+  final temp = Directory.systemTemp.createTempSync('sidekick_test');
+  final downloadDartSh = temp.file('tool/download_dart.sh')
+    ..createSync(recursive: true);
+  final downloadDartShOriginal = File(
+    '../sidekick/cli_template/bricks/package/__brick__/tool/download_dart.sh',
+  );
+  downloadDartShOriginal.copySync(downloadDartSh.path);
+  dcli.run('chmod 755 ${downloadDartSh.path}');
+
+  final dartRuntime = SidekickDartRuntime(temp);
+  dartRuntime.download();
+
+  return dartRuntime.dartSdkPath;
 }

--- a/sidekick_core/test/dart_command_test.dart
+++ b/sidekick_core/test/dart_command_test.dart
@@ -1,0 +1,75 @@
+import 'package:dcli/dcli.dart' as dcli;
+import 'package:sidekick_core/sidekick_core.dart';
+import 'package:test/test.dart';
+
+import 'init_test.dart';
+
+void main() {
+  final dartSdkPath = systemDartSdkPath()?.path;
+  final flutterSdkPath = systemFlutterSdkPath()?.path;
+  test(
+    'dart command works when dartSdkPath is set',
+    () async {
+      await insideFakeSidekickProject((dir) async {
+        final runner = initializeSidekick(
+          name: 'dash',
+          dartSdkPath: dartSdkPath,
+        );
+        runner.addCommand(DartCommand());
+        await runner.run(['dart']);
+      });
+    },
+    skip: dartSdkPath != null ? null : 'No Dart SDK found on system',
+  );
+
+  test('dart command fails when dartSdkPath is not set', () async {
+    await insideFakeSidekickProject((dir) async {
+      final runner = initializeSidekick(
+        name: 'dash',
+        // ignore: avoid_redundant_argument_values
+        dartSdkPath: null,
+      );
+      runner.addCommand(DartCommand());
+      try {
+        await runner.run(['dart']);
+        fail('did not throw');
+      } catch (e) {
+        expect(e, isA<DartSdkNotSetException>());
+      }
+    });
+  });
+
+  test(
+    'dart command links to embedded Dart SDK in Flutter SDK',
+    () async {
+      await insideFakeSidekickProject((dir) async {
+        final runner = initializeSidekick(
+          name: 'dash',
+          flutterSdkPath: flutterSdkPath,
+        );
+        runner.addCommand(DartCommand());
+        await runner.run(['dart']);
+      });
+    },
+    skip: flutterSdkPath != null ? null : 'No Flutter SDK found on system',
+  );
+}
+
+Directory? systemFlutterSdkPath() {
+  // Get path from "flutter doctor -v" printing the line
+  //     • Flutter version 2.2.0-10.1.pre at /usr/local/Caskroom/flutter/latest/flutter
+  final lines =
+      dcli.start('flutter doctor -v', progress: dcli.Progress.capture()).lines;
+  final flutterRepoPath = lines
+      .firstWhere((line) => line.contains("Flutter version"))
+      .split(" ")
+      .lastOrNull;
+  if (flutterRepoPath == null) {
+    return null;
+  }
+  return Directory(flutterRepoPath);
+}
+
+Directory? systemDartSdkPath() {
+  return systemFlutterSdkPath()?.directory('bin/cache/dart-sdk');
+}

--- a/sidekick_core/test/dart_command_test.dart
+++ b/sidekick_core/test/dart_command_test.dart
@@ -24,12 +24,7 @@ void main() {
         dartSdkPath: null,
       );
       runner.addCommand(DartCommand());
-      try {
-        await runner.run(['dart']);
-        fail('did not throw');
-      } catch (e) {
-        expect(e, isA<DartSdkNotSetException>());
-      }
+      expect(() => runner.run(['dart']), throwsA(isA<DartSdkNotSetException>()));
     });
   });
 

--- a/sidekick_core/test/dart_command_test.dart
+++ b/sidekick_core/test/dart_command_test.dart
@@ -24,7 +24,10 @@ void main() {
         dartSdkPath: null,
       );
       runner.addCommand(DartCommand());
-      expect(() => runner.run(['dart']), throwsA(isA<DartSdkNotSetException>()));
+      expect(
+        () => runner.run(['dart']),
+        throwsA(isA<DartSdkNotSetException>()),
+      );
     });
   });
 

--- a/sidekick_core/test/dart_command_test.dart
+++ b/sidekick_core/test/dart_command_test.dart
@@ -1,26 +1,20 @@
-import 'package:dcli/dcli.dart' as dcli;
 import 'package:sidekick_core/sidekick_core.dart';
 import 'package:test/test.dart';
 
+import 'fake_sdk.dart';
 import 'init_test.dart';
 
 void main() {
-  final dartSdkPath = anyDartSdk()?.path;
-  final flutterSdkPath = anyFlutterSdk()?.path;
-  test(
-    'dart command works when dartSdkPath is set',
-    () async {
-      await insideFakeSidekickProject((dir) async {
-        final runner = initializeSidekick(
-          name: 'dash',
-          dartSdkPath: dartSdkPath,
-        );
-        runner.addCommand(DartCommand());
-        await runner.run(['dart']);
-      });
-    },
-    skip: dartSdkPath != null ? null : 'No Dart SDK found on system',
-  );
+  test('dart command works when dartSdkPath is set', () async {
+    await insideFakeSidekickProject((dir) async {
+      final runner = initializeSidekick(
+        name: 'dash',
+        dartSdkPath: fakeDartSdk().path,
+      );
+      runner.addCommand(DartCommand());
+      await runner.run(['dart']);
+    });
+  });
 
   test('dart command fails when dartSdkPath is not set', () async {
     await insideFakeSidekickProject((dir) async {
@@ -39,20 +33,16 @@ void main() {
     });
   });
 
-  test(
-    'dart command links to embedded Dart SDK in Flutter SDK',
-    () async {
-      await insideFakeSidekickProject((dir) async {
-        final runner = initializeSidekick(
-          name: 'dash',
-          flutterSdkPath: flutterSdkPath,
-        );
-        runner.addCommand(DartCommand());
-        await runner.run(['dart']);
-      });
-    },
-    skip: flutterSdkPath != null ? null : 'No Flutter SDK found on system',
-  );
+  test('dart command links to embedded Dart SDK in Flutter SDK', () async {
+    await insideFakeSidekickProject((dir) async {
+      final runner = initializeSidekick(
+        name: 'dash',
+        flutterSdkPath: fakeFlutterSdk().path,
+      );
+      runner.addCommand(DartCommand());
+      await runner.run(['dart']);
+    });
+  });
 }
 
 Future<File> installFlutterWrapper(Directory directory) async {
@@ -63,44 +53,4 @@ Future<File> installFlutterWrapper(Directory directory) async {
   final exe = directory.file('flutterw');
   assert(exe.existsSync());
   return exe;
-}
-
-Directory? anyFlutterSdk() {
-  try {
-    // Get path from "flutter doctor -v" printing the line
-    //     • Flutter version 2.2.0-10.1.pre at /usr/local/Caskroom/flutter/latest/flutter
-    final lines = dcli
-        .start('flutter doctor -v', progress: dcli.Progress.capture())
-        .lines;
-    final flutterRepoPath = lines
-        .firstWhere((line) => line.contains("Flutter version"))
-        .split(" ")
-        .lastOrNull;
-    if (flutterRepoPath == null) {
-      return null;
-    }
-    return Directory(flutterRepoPath);
-  } catch (e) {
-    // No flutter installed, download it
-    final temp = Directory.systemTemp.createTempSync('sidekick_test');
-    dcli.run('git init', workingDirectory: temp.path);
-    installFlutterWrapper(temp);
-    return temp.directory('.flutter');
-  }
-}
-
-Directory? anyDartSdk() {
-  final temp = Directory.systemTemp.createTempSync('sidekick_test');
-  final downloadDartSh = temp.file('tool/download_dart.sh')
-    ..createSync(recursive: true);
-  final downloadDartShOriginal = File(
-    '../sidekick/cli_template/bricks/package/__brick__/tool/download_dart.sh',
-  );
-  downloadDartShOriginal.copySync(downloadDartSh.path);
-  dcli.run('chmod 755 ${downloadDartSh.path}');
-
-  final dartRuntime = SidekickDartRuntime(temp);
-  dartRuntime.download();
-
-  return dartRuntime.dartSdkPath;
 }

--- a/sidekick_core/test/fake_sdk.dart
+++ b/sidekick_core/test/fake_sdk.dart
@@ -1,0 +1,38 @@
+import 'package:dcli/dcli.dart' as dcli;
+import 'package:sidekick_core/sidekick_core.dart';
+import 'package:test/test.dart';
+
+/// Creates a fake Flutter SDK in temp with a `flutter` executable that does
+/// nothing besides "downloading" a fake Dart executable that does also nothing
+Directory fakeFlutterSdk() {
+  final temp = Directory.systemTemp.createTempSync('fake_flutter');
+  addTearDown(() => temp.deleteSync(recursive: true));
+
+  final flutterExe = temp.file('bin/flutter')
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+#!/bin/bash
+echo "fake Flutter executable"
+
+# Download dart SDK on execution
+mkdir -p ${temp.absolute.path}/bin/cache/dart-sdk/bin
+# write into file
+printf "#!/bin/bash\\necho \\"fake embedded Dart executable\\"\\n" > ${temp.absolute.path}/bin/cache/dart-sdk/bin/dart
+chmod 755 ${temp.absolute.path}/bin/cache/dart-sdk/bin/dart
+''');
+  dcli.run('chmod 755 ${flutterExe.path}');
+  return temp;
+}
+
+/// Creates a fake Dart SDK with a `dart` executable that does nothing
+Directory fakeDartSdk() {
+  final temp = Directory.systemTemp.createTempSync('fake_dart');
+  addTearDown(() => temp.deleteSync(recursive: true));
+
+  final exe = temp.file('bin/dart')
+    ..createSync(recursive: true)
+    ..writeAsStringSync('#!/bin/bash\necho "fake Dart executable"');
+  dcli.run('chmod 755 ${exe.path}');
+
+  return temp;
+}

--- a/sidekick_core/test/flutter_command_test.dart
+++ b/sidekick_core/test/flutter_command_test.dart
@@ -19,7 +19,7 @@ void main() {
     },
   );
 
-  test('flutter command fails when dartSdkPath is not set', () async {
+  test('flutter command fails when flutterSdkPath is not set', () async {
     await insideFakeSidekickProject((dir) async {
       final runner = initializeSidekick(
         name: 'dash',

--- a/sidekick_core/test/flutter_command_test.dart
+++ b/sidekick_core/test/flutter_command_test.dart
@@ -1,0 +1,40 @@
+import 'package:sidekick_core/sidekick_core.dart';
+import 'package:test/test.dart';
+
+import 'dart_command_test.dart';
+import 'init_test.dart';
+
+void main() {
+  final flutterSdkPath = systemFlutterSdkPath()?.path;
+  test(
+    'flutter command works when dartSdkPath is set',
+    () async {
+      await insideFakeSidekickProject((dir) async {
+        final runner = initializeSidekick(
+          name: 'dash',
+          flutterSdkPath: flutterSdkPath,
+        );
+        runner.addCommand(FlutterCommand());
+        await runner.run(['flutter']);
+      });
+    },
+    skip: flutterSdkPath != null ? null : 'no Dart SDK found on system',
+  );
+
+  test('flutter command fails when dartSdkPath is not set', () async {
+    await insideFakeSidekickProject((dir) async {
+      final runner = initializeSidekick(
+        name: 'dash',
+        // ignore: avoid_redundant_argument_values
+        flutterSdkPath: null,
+      );
+      runner.addCommand(FlutterCommand());
+      try {
+        await runner.run(['flutter']);
+        fail('did not throw');
+      } catch (e) {
+        expect(e, isA<FlutterSdkNotSetException>());
+      }
+    });
+  });
+}

--- a/sidekick_core/test/flutter_command_test.dart
+++ b/sidekick_core/test/flutter_command_test.dart
@@ -1,24 +1,22 @@
 import 'package:sidekick_core/sidekick_core.dart';
 import 'package:test/test.dart';
 
-import 'dart_command_test.dart';
+import 'fake_sdk.dart';
 import 'init_test.dart';
 
 void main() {
-  final flutterSdkPath = anyFlutterSdk()?.path;
   test(
     'flutter command works when dartSdkPath is set',
     () async {
       await insideFakeSidekickProject((dir) async {
         final runner = initializeSidekick(
           name: 'dash',
-          flutterSdkPath: flutterSdkPath,
+          flutterSdkPath: fakeFlutterSdk().path,
         );
         runner.addCommand(FlutterCommand());
         await runner.run(['flutter']);
       });
     },
-    skip: flutterSdkPath != null ? null : 'no Dart SDK found on system',
   );
 
   test('flutter command fails when dartSdkPath is not set', () async {

--- a/sidekick_core/test/flutter_command_test.dart
+++ b/sidekick_core/test/flutter_command_test.dart
@@ -5,7 +5,7 @@ import 'dart_command_test.dart';
 import 'init_test.dart';
 
 void main() {
-  final flutterSdkPath = systemFlutterSdkPath()?.path;
+  final flutterSdkPath = anyFlutterSdk()?.path;
   test(
     'flutter command works when dartSdkPath is set',
     () async {

--- a/sidekick_core/test/flutter_command_test.dart
+++ b/sidekick_core/test/flutter_command_test.dart
@@ -6,7 +6,7 @@ import 'init_test.dart';
 
 void main() {
   test(
-    'flutter command works when dartSdkPath is set',
+    'flutter command works when flutterSdkPath is set',
     () async {
       await insideFakeSidekickProject((dir) async {
         final runner = initializeSidekick(

--- a/sidekick_core/test/init_test.dart
+++ b/sidekick_core/test/init_test.dart
@@ -175,8 +175,11 @@ R insideFakeSidekickProject<R>(R Function(Directory projectDir) block) {
     ..writeAsStringSync('name: dash_sdk\n');
   tempDir.directory('lib').createSync();
 
+  env['SIDEKICK_PACKAGE_HOME'] = tempDir.absolute.path;
+
   addTearDown(() {
     tempDir.deleteSync(recursive: true);
+    env['SIDEKICK_PACKAGE_HOME'] = null;
   });
 
   return IOOverrides.runZoned(


### PR DESCRIPTION
This change allows pinning the Flutter/Dart SDK using `flutterw`, `fvm` or other mechanisms. 
All that has to change is setting the path in `initializeSidekick()`

```dart
final runner = initializeSidekick(
  name: 'dash',
  // New
  dartSdkPath: 'path/to/dart/sdk',
  flutterSdkPath: 'path/to/flutter/sdk',
);
```

Both, `<cli> dart` and `<cli> flutter` now check for those paths and crash otherwise.

API changes:
- Added `dartSdkPath` and `flutterSdkPath` to `initializeSidekick` 
- The `flutterw` is now deprecated in favor of the new `flutter` function
- ~**Breaking:** `flutter()` and `dart()` now don't check for the `flutter_wrapper` `.flutter` dir~
- `flutterw()` and `dart()` now print a warning when using the deprecated `flutter_wrapper` is used implicitly  
- The dart and flutter commands now don't call `exit` directly, instead only set the exit code

## TODO

- [x] make `flutterw` change non breaking
- [x] make tests without network access 