### PR TITLE
Generate README, .gitignore, and enable lints in plugin templates

### DIFF
--- a/sidekick/lib/src/init/init_command.dart
+++ b/sidekick/lib/src/init/init_command.dart
@@ -64,7 +64,7 @@ class InitCommand extends Command {
           }
           return name;
         }();
-    if (!isValidCliName(cliName)) {
+    if (!isValidPubPackageName(cliName)) {
       throw invalidCliNameErrorMessage;
     }
 

--- a/sidekick/lib/src/init/name_suggester.dart
+++ b/sidekick/lib/src/init/name_suggester.dart
@@ -4,6 +4,7 @@ import 'package:acronym/acronym.dart';
 import 'package:dartx/dartx.dart';
 import 'package:dcli/dcli.dart' as dcli;
 import 'package:path/path.dart' as p;
+import 'package:sidekick_core/sidekick_core.dart';
 
 /// Helps users to find a short, pregnant name for their CLI
 class NameSuggester {
@@ -86,7 +87,7 @@ class NameSuggester {
 
     return suggestions
         .map((e) => e.toLowerCase())
-        .where(isValidCliName)
+        .where(isValidPubPackageName)
         .toSet();
   }
 }
@@ -96,7 +97,7 @@ class CliNameValidator extends dcli.AskValidator {
 
   @override
   String validate(String line) {
-    if (!isValidCliName(line)) {
+    if (!isValidPubPackageName(line)) {
       throw dcli.AskValidatorException(dcli.red(invalidCliNameErrorMessage));
     }
 
@@ -106,11 +107,6 @@ class CliNameValidator extends dcli.AskValidator {
 
 const invalidCliNameErrorMessage = 'The CLI name must be valid: '
     'at least one lower case letter or underscore '
-    'followed by zero or more lower case letters, digits, or underscores.';
-
-// TODO replace with sidekick_core isValidPubPackageName once published
-// https://github.com/phntmxyz/sidekick/pull/62
-bool isValidCliName(String name) => _cliNameRegExp.hasMatch(name);
-
-// See https://dart.dev/tools/pub/pubspec#name and https://github.com/dart-lang/sdk/blob/8d262e294400d2f7e41f05579c088a6409a7b2bb/pkg/dartdev/lib/src/utils.dart#L95
-final RegExp _cliNameRegExp = RegExp(r'^[a-z_][a-z\d_]*$');
+    'followed by zero or more lower case letters, digits, or underscores. '
+    "Furthermore, make sure that it isn't a reserved word. "
+    'For details, see https://dart.dev/tools/pub/pubspec#name';

--- a/sidekick/lib/src/init/name_suggester.dart
+++ b/sidekick/lib/src/init/name_suggester.dart
@@ -1,7 +1,4 @@
-import 'dart:io';
-
 import 'package:acronym/acronym.dart';
-import 'package:dartx/dartx.dart';
 import 'package:dcli/dcli.dart' as dcli;
 import 'package:path/path.dart' as p;
 import 'package:sidekick_core/sidekick_core.dart';

--- a/sidekick/pubspec.lock
+++ b/sidekick/pubspec.lock
@@ -469,7 +469,7 @@ packages:
       name: sidekick_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.1"
+    version: "0.8.0"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/sidekick/pubspec.yaml
+++ b/sidekick/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   mason: 0.1.0-dev.4
   path: ^1.8.0
   recase: ^4.0.0
-  sidekick_core: '>=0.7.1 <1.0.0'
+  sidekick_core: '>=0.8.0 <1.0.0'
 
 dev_dependencies:
   lint: ^1.5.0

--- a/sidekick/test/plugins_test.dart
+++ b/sidekick/test/plugins_test.dart
@@ -124,18 +124,21 @@ void main() {
       run('dart analyze', workingDirectory: pluginPath);
       run('dart format --set-exit-if-changed $pluginPath');
 
-      expect(
-        pluginDir.file('analysis_options.yaml').readAsStringSync(),
-        _expectedAnalysisOptions,
-      );
-      expect(
-        pluginDir.file('.gitignore').readAsStringSync(),
-        _expectedGitignore,
-      );
-      expect(
-        pluginDir.file('README.md').readAsStringSync(),
-        _getExpectedReadme(template),
-      );
+      // TODO disabled until sidekick_core is updated
+      if (shouldUseLocalDevs) {
+        expect(
+          pluginDir.file('analysis_options.yaml').readAsStringSync(),
+          _expectedAnalysisOptions,
+        );
+        expect(
+          pluginDir.file('.gitignore').readAsStringSync(),
+          _expectedGitignore,
+        );
+        expect(
+          pluginDir.file('README.md').readAsStringSync(),
+          _getExpectedReadme(template),
+        );
+      }
     });
   }
 
@@ -215,7 +218,7 @@ the [pub tool](https://dart.dev/tools/pub/cmd/pub-global#activating-a-package).
 ### Installing a plugin from a pub server
 
 ```bash
-your_custom_sidekick_cli plugins install <plugin name on pub server, e.g. sidekick_vault>
+dashi plugins install <plugin name on pub server, e.g. sidekick_vault>
 ```
 
 By default, [pub.dev](https://pub.dev) is used as pub server. A custom pub server can be used with the `--hosted-url`
@@ -224,19 +227,19 @@ parameter.
 ### Installing a plugin from a git repository
 
 ```bash
-your_custom_sidekick_cli plugins install --source git <link to git repository>
+dashi plugins install --source git <link to git repository>
 ```
 
 #### Optional parameters:
 
 - `--git-ref`: Git branch name, tag or full commit SHA (40 characters) to be installed
 - `--git-path`: Path of git package in repository (use when repository root contains multiple packages)
-  - e.g. `your_custom_sidekick_cli plugins install --source git --git-path sidekick_vault https://github.com/phntmxyz/sidekick`
+  - e.g. `dashi plugins install --source git --git-path sidekick_vault https://github.com/phntmxyz/sidekick`
 
 ### Installing a plugin from a local path
 
 ```bash
-your_custom_sidekick_cli plugins install --source path <path to plugin on local machine>
+dashi plugins install --source path <path to plugin on local machine>
 ```
 
 ## Developing plugins
@@ -278,9 +281,9 @@ The `--template` parameter must be given one of the following values:
 
 ### Implementing functionality
 
-Every plugin needs a `tool/install.dart` file which is executed by the `your_custom_sidekick_cli plugins install` command.
+Every plugin needs a `tool/install.dart` file which is executed by the `dashi plugins install` command.
 This adds the plugin command to the custom sidekick CLI which is then available as 
-`your_custom_sidekick_cli <plugin-name>` (i.e. `your_custom_sidekick_cli generated-plugin`).  
+`dashi <plugin-name>` (i.e. `dashi generated-plugin`).  
 
 The plugin needs to be implemented in the generated `Command` class (i.e. `GeneratedPluginCommand`).
 

--- a/sidekick/test/plugins_test.dart
+++ b/sidekick/test/plugins_test.dart
@@ -1,6 +1,7 @@
 import 'package:dcli/dcli.dart';
 import 'package:recase/recase.dart';
 import 'package:sidekick_core/sidekick_core.dart';
+import 'package:sidekick_core/src/commands/plugins/create_plugin_command.dart';
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 
@@ -104,14 +105,7 @@ void main() {
     );
   });
 
-  // TODO: use CreatePluginCommand.templates.keys instead (import 'package:sidekick_core/src/commands/plugins/create_plugin_command.dart';)
-  const templates = [
-    'install-only',
-    'shared-command',
-    'shared-code',
-  ];
-
-  for (final template in templates) {
+  for (final template in CreatePluginCommand.templates.keys) {
     test('plugin template $template generates valid plugin code', () async {
       await runDashProcess([
         'plugins',
@@ -127,12 +121,11 @@ void main() {
 
       run('dart pub get', workingDirectory: pluginPath);
       run('dart analyze', workingDirectory: pluginPath);
-      // TODO enable when sidekick_core >0.7.1 is released
-      // run('dart format --set-exit-if-changed $pluginPath');
+      run('dart format --set-exit-if-changed $pluginPath');
     });
   }
 
-  for (final template in templates) {
+  for (final template in CreatePluginCommand.templates.keys) {
     test(
       'plugin e2e $template: create, install, run',
       () async {

--- a/sidekick/test/plugins_test.dart
+++ b/sidekick/test/plugins_test.dart
@@ -117,11 +117,25 @@ void main() {
         projectRoot.path,
       ]);
 
-      final pluginPath = projectRoot.directory('generated_plugin').path;
+      final pluginDir = projectRoot.directory('generated_plugin');
+      final pluginPath = pluginDir.path;
 
       run('dart pub get', workingDirectory: pluginPath);
       run('dart analyze', workingDirectory: pluginPath);
       run('dart format --set-exit-if-changed $pluginPath');
+
+      expect(
+        pluginDir.file('analysis_options.yaml').readAsStringSync(),
+        _expectedAnalysisOptions,
+      );
+      expect(
+        pluginDir.file('.gitignore').readAsStringSync(),
+        _expectedGitignore,
+      );
+      expect(
+        pluginDir.file('README.md').readAsStringSync(),
+        _getExpectedReadme(template),
+      );
     });
   }
 
@@ -156,3 +170,124 @@ void main() {
     );
   }
 }
+
+const _expectedAnalysisOptions = '''
+include: package:lint/analysis_options.yaml
+''';
+
+const _expectedGitignore = '''
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock
+''';
+
+String _getExpectedReadme(String templateType) => '''
+# generated_plugin sidekick plugin
+
+A plugin for [sidekick CLIs](https://pub.dev/packages/sidekick).  
+Generated from template `$templateType`.
+
+## Description
+
+[sidekick](https://pub.dev/packages/sidekick) generates custom command line apps for automating tasks.  
+Plugins encapsulate certain tasks and can be used to easily extend the capabilities of a sidekick CLI.
+
+Take a look at the available [sidekick plugins on pub.dev](https://pub.dev/packages?q=dependency%3Asidekick_core).
+
+
+## Installation
+
+### Prerequisites:
+
+- install `sidekick`: `dart pub global activate sidekick`
+- generate custom sidekick CLI: `sidekick init`
+
+Installing plugins to a custom sidekick CLI is very similar to installing a package with
+the [pub tool](https://dart.dev/tools/pub/cmd/pub-global#activating-a-package).
+
+### Installing a plugin from a pub server
+
+```bash
+your_custom_sidekick_cli plugins install <plugin name on pub server, e.g. sidekick_vault>
+```
+
+By default, [pub.dev](https://pub.dev) is used as pub server. A custom pub server can be used with the `--hosted-url`
+parameter.
+
+### Installing a plugin from a git repository
+
+```bash
+your_custom_sidekick_cli plugins install --source git <link to git repository>
+```
+
+#### Optional parameters:
+
+- `--git-ref`: Git branch name, tag or full commit SHA (40 characters) to be installed
+- `--git-path`: Path of git package in repository (use when repository root contains multiple packages)
+  - e.g. `your_custom_sidekick_cli plugins install --source git --git-path sidekick_vault https://github.com/phntmxyz/sidekick`
+
+### Installing a plugin from a local path
+
+```bash
+your_custom_sidekick_cli plugins install --source path <path to plugin on local machine>
+```
+
+## Developing plugins
+
+### Plugin templates
+
+A plugin template can be generated with `sidekick plugins create --template <template type> --name <plugin name>`.
+
+This plugin was generated from the template `$templateType`.
+
+The `--template` parameter must be given one of the following values:
+
+- `install-only`  
+  This template is the very minimum, featuring just a `tool/install.dart` file
+  that writes all code to be installed into the users sidekick CLI.
+
+  It doesn't add a pub dependency with shared code. All code is generated in
+  the users sidekick CLI, being fully adjustable.
+
+
+- `shared-command`  
+  This template adds a pub dependency to a shared CLI `Command` and registers
+  it in the user's sidekick CLI.
+
+  This method is designed for cases where the command might be configurable
+  with parameters but doesn't allow users to actually change the code.
+
+  It allows updates (via `pub upgrade`) without users having to touch their code.
+
+
+- `shared-code`  
+  This template adds a pub dependency and writes the code of a `Command` into
+  the user's sidekick CLI as well as registers it there.
+ 
+  The `Command` code is not shared, thus is highly customizable. But it uses
+  shared code from the plugin package that is registered added as dependency.
+  Update of the helper functions is possible via pub, but the actual command
+  flow is up to the user.
+
+### Implementing functionality
+
+Every plugin needs a `tool/install.dart` file which is executed by the `your_custom_sidekick_cli plugins install` command.
+This adds the plugin command to the custom sidekick CLI which is then available as 
+`your_custom_sidekick_cli <plugin-name>` (i.e. `your_custom_sidekick_cli generated-plugin`).  
+
+The plugin needs to be implemented in the generated `Command` class (i.e. `GeneratedPluginCommand`).
+
+Use the `argParser` attribute in the constructor to add parameters or subcommands (e.g. `argParser.addOption(...)`).
+
+Implement the functionality in the `run` method of the command. Here following helpers are accessible:
+- Execute Dart and Flutter commands with the `dart` and `flutter` functions.  
+  The Dart runtime bundled with the custom sidekick CLI is accesible through `sidekickDartRuntime.dart`.
+- Use the generated `<your sidekick CLI name>Project` variable to access other packages.
+''';

--- a/sidekick_core/lib/src/commands/plugins/create_plugin_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_plugin_command.dart
@@ -71,6 +71,7 @@ class CreatePluginCommand extends Command {
     final templateProperties = TemplateProperties(
       pluginName: name,
       pluginDirectory: pluginDirectory,
+      templateType: template,
     );
 
     final TemplateGenerator generator = templates[template]!;

--- a/sidekick_core/lib/src/commands/plugins/create_templates/install_only.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/install_only.dart
@@ -19,6 +19,8 @@ class InstallOnlyTemplate extends TemplateGenerator {
 
     final toolDirectory = pluginDirectory.directory('tool')..createSync();
     toolDirectory.file('install.dart').writeAsStringSync(props.installTemplate);
+
+    super.generate(props);
   }
 }
 
@@ -36,6 +38,7 @@ dependencies:
 
 dev_dependencies:
   sidekick_plugin_installer: ^0.1.3
+  lint: ^1.5.0
 ''';
 
   String get installTemplate => '''

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
@@ -3,7 +3,7 @@ import 'package:sidekick_core/sidekick_core.dart';
 import 'package:sidekick_core/src/commands/plugins/create_templates/template_generator.dart';
 
 /// This template adds a pub dependency and writes the code of a [Command] into
-/// the user's sidekick CLI
+/// the user's sidekick CLI as well as registers it there.
 ///
 /// The [Command] code is not shared, thus is highly customizable. But it uses
 /// shared code from the plugin package that is registered added as dependency.
@@ -26,6 +26,8 @@ class SharedCodeTemplate extends TemplateGenerator {
     libDirectory
         .file('${props.pluginName.snakeCase}.dart')
         .writeAsStringSync(props.helpers);
+
+    super.generate(props);
   }
 }
 
@@ -43,6 +45,7 @@ dependencies:
 
 dev_dependencies:
   sidekick_plugin_installer: ^0.1.3
+  lint: ^1.5.0
 ''';
 
   String get installTemplate => '''
@@ -54,7 +57,7 @@ Future<void> main() async {
   final SidekickPackage package = PluginContext.sidekickPackage;
 
   if (PluginContext.localPlugin == null) {
-    pubAddDependency(package, 'sidekick_flutter');
+    pubAddDependency(package, ${pluginName.snakeCase});
   } else {
     // For local development
     pubAddLocalDependency(package, PluginContext.localPlugin!.root.path);

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
@@ -57,7 +57,7 @@ Future<void> main() async {
   final SidekickPackage package = PluginContext.sidekickPackage;
 
   if (PluginContext.localPlugin == null) {
-    pubAddDependency(package, ${pluginName.snakeCase});
+    pubAddDependency(package, '${pluginName.snakeCase}');
   } else {
     // For local development
     pubAddLocalDependency(package, PluginContext.localPlugin!.root.path);

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
@@ -2,12 +2,13 @@ import 'package:recase/recase.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 import 'package:sidekick_core/src/commands/plugins/create_templates/template_generator.dart';
 
-/// This template adds pub dependency and registers a shared cli [Command] that pub package
+/// This template adds a pub dependency to a shared CLI [Command] and registers
+/// it in the user's sidekick CLI.
 ///
 /// This method is designed for cases where the command might be configurable
 /// with parameters but doesn't allow users to actually change the code.
 ///
-/// It allows updates (via pub upgrade) without users having to touch their code.
+/// It allows updates (via `pub upgrade`) without users having to touch their code.
 class SharedCommandTemplate extends TemplateGenerator {
   const SharedCommandTemplate();
 
@@ -25,6 +26,8 @@ class SharedCommandTemplate extends TemplateGenerator {
     libDirectory
         .file('${props.pluginName.snakeCase}_command.dart')
         .writeAsStringSync(props.exampleCommand);
+
+    super.generate(props);
   }
 }
 
@@ -42,6 +45,7 @@ dependencies:
 
 dev_dependencies:
   sidekick_plugin_installer: ^0.1.3
+  lint: ^1.5.0
 ''';
 
   String get installTemplate => '''
@@ -53,7 +57,7 @@ Future<void> main() async {
   final SidekickPackage package = PluginContext.sidekickPackage;
 
   if (PluginContext.localPlugin == null) {
-    pubAddDependency(package, 'sidekick_flutter');
+    pubAddDependency(package, '${pluginName.snakeCase}');
   } else {
     // For local development
     pubAddLocalDependency(package, PluginContext.localPlugin!.root.path);

--- a/sidekick_core/lib/src/commands/plugins/create_templates/template_generator.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/template_generator.dart
@@ -85,7 +85,7 @@ the [pub tool](https://dart.dev/tools/pub/cmd/pub-global#activating-a-package).
 ### Installing a plugin from a pub server
 
 ```bash
-your_custom_sidekick_cli plugins install <plugin name on pub server, e.g. sidekick_vault>
+${pluginName.snakeCase} plugins install <plugin name on pub server, e.g. sidekick_vault>
 ```
 
 By default, [pub.dev](https://pub.dev) is used as pub server. A custom pub server can be used with the `--hosted-url`
@@ -94,19 +94,19 @@ parameter.
 ### Installing a plugin from a git repository
 
 ```bash
-your_custom_sidekick_cli plugins install --source git <link to git repository>
+$cliName plugins install --source git <link to git repository>
 ```
 
 #### Optional parameters:
 
 - `--git-ref`: Git branch name, tag or full commit SHA (40 characters) to be installed
 - `--git-path`: Path of git package in repository (use when repository root contains multiple packages)
-  - e.g. `your_custom_sidekick_cli plugins install --source git --git-path sidekick_vault https://github.com/phntmxyz/sidekick`
+  - e.g. `$cliName plugins install --source git --git-path sidekick_vault https://github.com/phntmxyz/sidekick`
 
 ### Installing a plugin from a local path
 
 ```bash
-your_custom_sidekick_cli plugins install --source path <path to plugin on local machine>
+$cliName plugins install --source path <path to plugin on local machine>
 ```
 
 ## Developing plugins
@@ -148,9 +148,9 @@ The `--template` parameter must be given one of the following values:
 
 ### Implementing functionality
 
-Every plugin needs a `tool/install.dart` file which is executed by the `your_custom_sidekick_cli plugins install` command.
+Every plugin needs a `tool/install.dart` file which is executed by the `$cliName plugins install` command.
 This adds the plugin command to the custom sidekick CLI which is then available as 
-`your_custom_sidekick_cli <plugin-name>` (i.e. `your_custom_sidekick_cli ${pluginName.paramCase}`).  
+`$cliName <plugin-name>` (i.e. `$cliName ${pluginName.paramCase}`).  
 
 The plugin needs to be implemented in the generated `Command` class (i.e. `${pluginName.pascalCase}Command`).
 

--- a/sidekick_core/lib/src/commands/plugins/create_templates/template_generator.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/template_generator.dart
@@ -85,7 +85,7 @@ the [pub tool](https://dart.dev/tools/pub/cmd/pub-global#activating-a-package).
 ### Installing a plugin from a pub server
 
 ```bash
-${pluginName.snakeCase} plugins install <plugin name on pub server, e.g. sidekick_vault>
+$cliName plugins install <plugin name on pub server, e.g. sidekick_vault>
 ```
 
 By default, [pub.dev](https://pub.dev) is used as pub server. A custom pub server can be used with the `--hosted-url`

--- a/sidekick_core/lib/src/commands/plugins/create_templates/template_generator.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/template_generator.dart
@@ -1,11 +1,26 @@
-import 'dart:io';
+import 'package:meta/meta.dart';
+import 'package:recase/recase.dart';
+import 'package:sidekick_core/sidekick_core.dart';
 
 /// A file structure template that can be written to disk
 abstract class TemplateGenerator {
   const TemplateGenerator();
 
   /// Generates the template and writes it to [TemplateProperties.pluginDirectory]
-  void generate(TemplateProperties props);
+  @mustCallSuper
+  void generate(TemplateProperties props) {
+    props.pluginDirectory
+        .file('analysis_options.yaml')
+        .writeAsStringSync(props.analysisOptionsTemplate);
+
+    props.pluginDirectory
+        .file('.gitignore')
+        .writeAsStringSync(props.gitignoreTemplate);
+
+    props.pluginDirectory
+        .file('README.md')
+        .writeAsStringSync(props.readmeTemplate);
+  }
 }
 
 class TemplateProperties {
@@ -15,8 +30,135 @@ class TemplateProperties {
   /// Where the files should be written to. This is considered as root directory
   final Directory pluginDirectory;
 
+  /// The type of template to generate. Also see [CreatePluginCommand.templates]
+  final String templateType;
+
   const TemplateProperties({
     required this.pluginName,
     required this.pluginDirectory,
+    required this.templateType,
   });
+}
+
+extension on TemplateProperties {
+  String get analysisOptionsTemplate => '''
+include: package:lint/analysis_options.yaml
+''';
+
+  String get gitignoreTemplate => '''
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock
+''';
+
+  String get readmeTemplate => '''
+# $pluginName sidekick plugin
+
+A plugin for [sidekick CLIs](https://pub.dev/packages/sidekick).  
+Generated from template `$templateType`.
+
+## Description
+
+[sidekick](https://pub.dev/packages/sidekick) generates custom command line apps for automating tasks.  
+Plugins encapsulate certain tasks and can be used to easily extend the capabilities of a sidekick CLI.
+
+Take a look at the available [sidekick plugins on pub.dev](https://pub.dev/packages?q=dependency%3Asidekick_core).
+
+
+## Installation
+
+### Prerequisites:
+
+- install `sidekick`: `dart pub global activate sidekick`
+- generate custom sidekick CLI: `sidekick init`
+
+Installing plugins to a custom sidekick CLI is very similar to installing a package with
+the [pub tool](https://dart.dev/tools/pub/cmd/pub-global#activating-a-package).
+
+### Installing a plugin from a pub server
+
+```bash
+your_custom_sidekick_cli plugins install <plugin name on pub server, e.g. sidekick_vault>
+```
+
+By default, [pub.dev](https://pub.dev) is used as pub server. A custom pub server can be used with the `--hosted-url`
+parameter.
+
+### Installing a plugin from a git repository
+
+```bash
+your_custom_sidekick_cli plugins install --source git <link to git repository>
+```
+
+#### Optional parameters:
+
+- `--git-ref`: Git branch name, tag or full commit SHA (40 characters) to be installed
+- `--git-path`: Path of git package in repository (use when repository root contains multiple packages)
+  - e.g. `your_custom_sidekick_cli plugins install --source git --git-path sidekick_vault https://github.com/phntmxyz/sidekick`
+
+### Installing a plugin from a local path
+
+```bash
+your_custom_sidekick_cli plugins install --source path <path to plugin on local machine>
+```
+
+## Developing plugins
+
+### Plugin templates
+
+A plugin template can be generated with `sidekick plugins create --template <template type> --name <plugin name>`.
+
+This plugin was generated from the template `$templateType`.
+
+The `--template` parameter must be given one of the following values:
+
+- `install-only`  
+  This template is the very minimum, featuring just a `tool/install.dart` file
+  that writes all code to be installed into the users sidekick CLI.
+
+  It doesn't add a pub dependency with shared code. All code is generated in
+  the users sidekick CLI, being fully adjustable.
+
+
+- `shared-command`  
+  This template adds a pub dependency to a shared CLI `Command` and registers
+  it in the user's sidekick CLI.
+
+  This method is designed for cases where the command might be configurable
+  with parameters but doesn't allow users to actually change the code.
+
+  It allows updates (via `pub upgrade`) without users having to touch their code.
+
+
+- `shared-code`  
+  This template adds a pub dependency and writes the code of a `Command` into
+  the user's sidekick CLI as well as registers it there.
+ 
+  The `Command` code is not shared, thus is highly customizable. But it uses
+  shared code from the plugin package that is registered added as dependency.
+  Update of the helper functions is possible via pub, but the actual command
+  flow is up to the user.
+
+### Implementing functionality
+
+Every plugin needs a `tool/install.dart` file which is executed by the `your_custom_sidekick_cli plugins install` command.
+This adds the plugin command to the custom sidekick CLI which is then available as 
+`your_custom_sidekick_cli <plugin-name>` (i.e. `your_custom_sidekick_cli ${pluginName.paramCase}`).  
+
+The plugin needs to be implemented in the generated `Command` class (i.e. `${pluginName.pascalCase}Command`).
+
+Use the `argParser` attribute in the constructor to add parameters or subcommands (e.g. `argParser.addOption(...)`).
+
+Implement the functionality in the `run` method of the command. Here following helpers are accessible:
+- Execute Dart and Flutter commands with the `dart` and `flutter` functions.  
+  The Dart runtime bundled with the custom sidekick CLI is accesible through `sidekickDartRuntime.dart`.
+- Use the generated `<your sidekick CLI name>Project` variable to access other packages.
+''';
 }

--- a/sidekick_core/pubspec.yaml
+++ b/sidekick_core/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   args: ^2.1.0
   dartx: '>=0.7.1 <2.0.0'
   dcli: '>=1.15.0 <1.31.0' # 1.17 requires Dart 2.16 https://github.com/noojee/dcli/pull/192
+  meta: ^1.5.0
   recase: ^4.1.0
   yaml: ^3.1.0
 


### PR DESCRIPTION
Fixes #66, #68, and #69

Plugin templates:
- Generate `analysis_options.yaml` and enable lints
- Generate `.gitignore`
- Generate `README.md`

Also resolves some TODOs after updating to `sidekick_core` v0.8.0