### PR TITLE
Add library to shared-command + shared-code templates

### DIFF
--- a/sidekick_core/lib/src/commands/plugins/create_plugin_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_plugin_command.dart
@@ -21,7 +21,7 @@ class CreatePluginCommand extends Command {
     argParser.addOption(
       'name',
       abbr: 'n',
-      help: 'The plugin name',
+      help: 'The plugin name (should end with _sidekick_plugin)',
     );
 
     argParser.addOption(

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
@@ -105,6 +105,8 @@ class ${pluginName.pascalCase}Command extends Command {
 ''';
 
   String get helpers => '''
+library ${pluginName.snakeCase};
+
 List<String> getGreetings() => [
       'Moin',
       'Servus',

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
@@ -24,7 +24,12 @@ class SharedCommandTemplate extends TemplateGenerator {
 
     final libDirectory = pluginDirectory.directory('lib')..createSync();
     libDirectory
-        .file('${props.pluginName.snakeCase}_command.dart')
+        .file('${props.pluginName.snakeCase}.dart')
+        .writeAsStringSync(props.library);
+
+    final srcDir = libDirectory.directory('src')..createSync();
+    srcDir
+        .file('${props.commandName.snakeCase}_command.dart')
         .writeAsStringSync(props.exampleCommand);
 
     super.generate(props);
@@ -66,23 +71,29 @@ Future<void> main() async {
 
   registerPlugin(
     sidekickCli: package,
-    import: "import 'package:$pluginName/${pluginName.snakeCase}_command.dart';",
+    import: "import 'package:$pluginName/${pluginName.snakeCase}.dart';",
     command: '${pluginName.pascalCase}Command()',
   );
 }
 ''';
 
+  String get library => '''
+library ${pluginName.snakeCase};
+
+export 'package:${pluginName.snakeCase}/src/${commandName.snakeCase}_command.dart';
+''';
+
   String get exampleCommand => '''
 import 'package:sidekick_core/sidekick_core.dart';
 
-class ${pluginName.pascalCase}Command extends Command {
+class ${commandName.pascalCase}Command extends Command {
   @override
   final String description = 'Sample command';
 
   @override
-  final String name = '${pluginName.paramCase}';
+  final String name = '$commandName';
 
-  ${pluginName.pascalCase}Command() {
+  ${commandName.pascalCase}Command() {
     // add parameters here with argParser.addOption
   }
 

--- a/sidekick_core/lib/src/commands/plugins/create_templates/template_generator.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/template_generator.dart
@@ -27,6 +27,11 @@ class TemplateProperties {
   /// The name of the to be generated plugin
   final String pluginName;
 
+  /// The name of the command that will be generated
+  String get commandName {
+    return pluginName.replaceAll('_sidekick_plugin', '').paramCase;
+  }
+
   /// Where the files should be written to. This is considered as root directory
   final Directory pluginDirectory;
 


### PR DESCRIPTION
This creates a typical `package:name/name.dart` import instead of  `package:name/name_command.dart`