### PR TITLE
Update vault install script to be compatible with latest plugin installer

### DIFF
--- a/sidekick_vault/tool/install.dart
+++ b/sidekick_vault/tool/install.dart
@@ -2,11 +2,15 @@ import 'package:sidekick_core/sidekick_core.dart'
     hide cliName, repository, mainProject;
 import 'package:sidekick_plugin_installer/sidekick_plugin_installer.dart';
 
-Future<void> main(List<String> args) async {
-  // The installer injects the path to the sidekick project as first argument
-  final package = SidekickPackage.fromDirectory(Directory(args[0]))!;
+Future<void> main() async {
+  final SidekickPackage package = PluginContext.sidekickPackage;
 
-  pubAddDependency(package, 'sidekick_vault');
+  if (PluginContext.localPlugin == null) {
+    pubAddDependency(package, 'sidekick_vault');
+  } else {
+    // For local development
+    pubAddLocalDependency(package, PluginContext.localPlugin!.root.path);
+  }
   pubGet(package);
 
   _writeVaultFile(package);


### PR DESCRIPTION
How to test

```bash
<cli> sidekick plugins install -s path ~/github/phntmxyz/sidekick/sidekick_vault  
```

I will publish it now and make it our first plugin :)