### PR TITLE
Fix `install-global` command

### DIFF
--- a/sidekick_core/lib/src/commands/install_global_command.dart
+++ b/sidekick_core/lib/src/commands/install_global_command.dart
@@ -38,10 +38,16 @@ class InstallGlobalCommand extends Command {
 
   void _addBinDirToPathOrPrint() {
     final binDirPath = GlobalSidekickRoot.binDirWithHomeEnv;
-    final added = Shell.current.appendToPATH(binDirPath);
-    if (added) {
-      printerr('Added $binDirPath to PATH');
-      return;
+    try {
+      // depending on the shell and dcli version, this can throw.
+      // E.g. dcli-1.30.3 zsh_shell.dart: UnsupportedError('Not supported in zsh')
+      final added = Shell.current.appendToPATH(binDirPath);
+      if (added) {
+        printerr('Added $binDirPath to PATH');
+        return;
+      }
+    } catch (_) {
+      // ignore
     }
 
     print(


### PR DESCRIPTION
On `sidekick` v0.7.0:
```
❯ ./a sidekick install-global
Unhandled exception:
Unsupported operation: Not supported in zsh
#0      ZshShell.appendToPATH (package:dcli/src/shell/zsh_shell.dart:57)
#1      InstallGlobalCommand._addBinDirToPathOrPrint (package:sidekick_core/src/commands/install_global_command.dart:41)
#2      InstallGlobalCommand.run (package:sidekick_core/src/commands/install_global_command.dart:36)
#3      CommandRunner.runCommand (package:args/command_runner.dart:209)
#4      CommandRunner.run.<anonymous closure> (package:args/command_runner.dart:119)
#5      new Future.sync (dart:async/future.dart:302)
#6      CommandRunner.run (package:args/command_runner.dart:119)
#7      SidekickCommandRunner.run (package:sidekick_core/sidekick_core.dart:128)
#8      runA (package:a_sidekick/a_sidekick.dart:30)
#9      main (file:///Users/pepe/repos/samples/abc/packages/a_sidekick/bin/main.dart:4)
#10     _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:295)
#11     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192)
```

This is because in `InstallGlobalCommand`, `Shell.appendToPATH` (from `dcli`) is called.

In `dcli` v1.16.3 `ZshShell.appendToPATH` is implemented like this:

```dart
  @override
  bool appendToPATH(String path) => false;
```

While in `dcli` v1.30.3 it is implemented like this:

```dart
  @override
  bool appendToPATH(String path) =>
      throw UnsupportedError('Not supported in zsh');
```

Thus we need to wrap our call to `appendToPATH` in a try-catch block to make the `InstallGlobalCommand` work without crashing.