### PR TITLE
Improve pub score by adding `example/README.md` and allowing latest `dcli` version

### DIFF
--- a/sidekick/example/README.md
+++ b/sidekick/example/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/sidekick/lib/sidekick.dart
+++ b/sidekick/lib/sidekick.dart
@@ -4,6 +4,8 @@ import 'package:args/command_runner.dart';
 import 'package:sidekick/src/init/init_command.dart';
 import 'package:sidekick/src/plugins/plugins_command.dart';
 
+/// See the [README](https://github.com/phntmxyz/sidekick/blob/main/sidekick/README.md)
+/// for more information on sidekick
 Future<void> main(List<String> args) async {
   final runner = _SidekickCommandRunner()
     ..addCommand(InitCommand())

--- a/sidekick_core/example/README.md
+++ b/sidekick_core/example/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/sidekick_core/pubspec.yaml
+++ b/sidekick_core/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ^2.1.0
   dartx: '>=0.7.1 <2.0.0'
-  dcli: '>=1.15.0 <1.31.0' # 1.17 requires Dart 2.16 https://github.com/noojee/dcli/pull/192
+  dcli: ^1.15.0
   meta: ^1.5.0
   recase: ^4.1.0
   yaml: ^3.1.0

--- a/sidekick_plugin_installer/example/README.md
+++ b/sidekick_plugin_installer/example/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/sidekick_vault/example/README.md
+++ b/sidekick_vault/example/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
1. `sidekick`, `sidekick_core`, and `sidekick_plugin_installer` now have an `example` directory which contains a link to the package's `README.md`: +10 pub points each https://dart.dev/tools/pub/package-layout#examples
<img width="373" alt="image" src="https://user-images.githubusercontent.com/39117631/198315378-d21f00f5-7f3d-4a4c-864e-01b9199116d3.png">

2. `sidekick_core` now allows to use the latest `dcli` version (`^1.15.0` instead of `>=1.15.0 <1.31.0`): +10 pub points
<img width="779" alt="image" src="https://user-images.githubusercontent.com/39117631/198315881-0f941068-5691-4320-ad1d-71841365737a.png">

<details>
  <summary>I tested this with Flutter 2.5.3 and Dart 2.14.4 and it works correctly (the previous version of sidekick_core/pubspec.yaml suggested this wouldn't work because Dart 2.16 would be required with dcli ^1.15.0)</summary>

```
# Set this in sidekick/pubspec.yaml:
# dependency_overrides:
#   sidekick_core:
#     path: /Users/pepe/repos/sidekick/sidekick_core # this now has dcli: ^1.15.0


❯ dart --version
Dart SDK version: 2.14.4 (stable) (Wed Oct 13 11:11:32 2021 +0200) on "macos_x64"
❯ flutter --version
Flutter 2.5.3 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 18116933e7 (1 year ago) • 2021-10-15 10:46:35 -0700
Engine • revision d3ea636dc5
Tools • Dart 2.14.4
❯ dart pub global activate -s path /Users/pepe/repos/sidekick/sidekick
Resolving dependencies... 
  _fe_analyzer_shared 39.0.0 (50.0.0 available)
  analyzer 4.0.0 (5.2.0 available)
  async 2.9.0 (2.10.0 available)
  basic_utils 3.9.4 (5.4.0 available)
  boolean_selector 2.1.0 (2.1.1 available)
  circular_buffer 0.9.1 (0.11.0 available)
  convert 3.1.0 (3.1.1 available)
  coverage 1.2.0 (1.6.1 available)
  dart_console 1.0.0 (1.1.2 available)
  dcli 1.21.1 (1.35.4 available)
  dcli_core 1.21.1 (1.35.4 available)
  ffi 1.2.1 (2.0.1 available)
  file_utils 1.0.1 (discontinued)
  frontend_server_client 2.1.3 (3.1.0 available)
  glob 2.0.2 (2.1.0 available)
  globbing 1.0.0 (discontinued)
  js 0.6.3 (0.6.5 available)
  json_annotation 4.6.0 (4.7.0 available)
  lint 1.7.2 (1.10.0 available)
  mason 0.1.0-dev.4 (0.1.0-dev.34 available)
  mason_cli 0.1.0-dev.6 (0.1.0-dev.37 available)
  mason_logger 0.1.0-dev.4 (0.2.1 available)
  matcher 0.12.12 (0.12.13 available)
  posix 2.2.3 (4.1.0 available)
  settings_yaml 3.5.0 (4.0.0 available)
  shelf 1.2.0 (1.4.0 available)
  source_maps 0.10.10 (0.10.11 available)
  stack_trace 1.10.0 (1.11.0 available)
  stacktrace_impl 2.3.0 (discontinued replaced by stack_trace)
  test 1.21.4 (1.21.7 available)
  test_api 0.4.12 (0.4.15 available)
  test_core 0.4.16 (0.4.19 available)
  test_process 2.0.2 (2.0.3 available)
  vm_service 8.2.2 (9.4.0 available)
  win32 2.3.6 (3.0.1 available)
Warning: You are using these overridden dependencies:
! sidekick_core 0.10.1 from path /Users/pepe/repos/sidekick/sidekick_core
Got dependencies in /Users/pepe/repos/sidekick/sidekick!
Installed executable sidekick.
Activated sidekick 0.7.1 at path "/Users/pepe/repos/sidekick/sidekick".
```

`pub` correctly got `dcli`1.21.1 which is the latest version supporting Dart 2.14.4: https://pub.dev/packages/dcli/versions

I then also verified that the sidekick CLI works correctly:
- `sidekick init` -> generate my `dashito` sidekick CLI ✅
- `./dashito` ✅
- `./dashito ` ✅
- `./dashito sidekick plugins create -t install-only -n a_plugin` ✅
- `./dashito sidekick plugins install -s path a_plugin` ✅
- `./dashito a-plugin` ✅

```
Activated sidekick 0.7.1 at path "/Users/pepe/repos/sidekick/sidekick".
❯ cd /Users/pepe/repos/samples/new_project
❯ sidekick init
Welcome to sidekick. You're about to initialize a sidekick project

Please select a name for your sidekick CLI.
We know, selecting a name is hard. Here are some suggestions:
  1) p
  2) pj
  3) sp
  4) nt
  5) sppj
  6) Enter your own
Type the number of the fitting acronym or choose Enter your own 6
Enter your CLI name dashito

Generating dashito_sidekick
Analyzing project structure in /Users/pepe/repos/samples/new_project
Initialized empty Git repository in /Users/pepe/repos/samples/new_project/.git/
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint:   git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint:   git branch -m <name>
Using cached Dart SDK 2.18.2 from /Users/pepe/.dart/sdk/cache/dartsdk-macos-arm64-release.zip...
Resolving dependencies... (1.7s)
+ archive 3.3.2
+ args 2.3.1
+ async 2.10.0
+ basic_utils 3.9.4 (5.4.0 available)
+ characters 1.2.1
+ chunked_stream 1.4.1
+ circular_buffer 0.11.0
+ clock 1.1.1
+ collection 1.17.0
+ convert 3.1.1
+ crypto 3.0.2
+ csv 5.0.1
+ dart_console 1.1.2
+ dartx 1.1.0
+ dcli 1.30.3 (1.35.4 available)
+ dcli_core 1.34.1 (1.35.4 available)
+ equatable 2.0.5
+ ffi 1.2.1 (2.0.1 available)
+ file 6.1.4
+ file_utils 1.0.1
+ glob 2.1.0
+ globbing 1.0.0
+ http 0.13.5
+ http_parser 4.0.2
+ ini 2.1.0
+ intl 0.17.0
+ js 0.6.5
+ json_annotation 4.7.0
+ lint 1.10.0
+ logging 1.1.0
+ matcher 0.12.13
+ meta 1.8.0
+ mime 1.0.2
+ path 1.8.2
+ pointycastle 3.6.2
+ posix 3.1.0 (4.1.0 available)
+ pub_semver 2.1.2
+ pubspec 2.3.0
+ quiver 3.1.0
+ random_string 2.3.1
+ recase 4.1.0
+ scope 2.2.1 (3.0.0 available)
+ settings_yaml 3.5.0 (4.0.0 available)
+ sidekick_core 0.10.1
+ source_span 1.9.1
+ stack_trace 1.11.0
+ stacktrace_impl 2.3.0
+ string_scanner 1.1.1
+ system_info2 2.0.4
+ term_glyph 1.2.1
+ time 2.1.3
+ typed_data 1.3.1
+ uri 1.0.0
+ uuid 3.0.6
+ validators2 3.0.0
+ vin_decoder 0.2.1-nullsafety
+ win32 2.6.1 (3.0.1 available)
+ yaml 3.1.1
Downloading sidekick_core 0.10.1...
Downloading lint 1.10.0...
Downloading dcli 1.30.3...
Downloading posix 3.1.0...
Downloading win32 2.6.1...
Downloading scope 2.2.1...
Downloading glob 2.1.0...
Downloading convert 3.1.1...
Downloading matcher 0.12.13...
Downloading stack_trace 1.11.0...
Downloading dart_console 1.1.2...
Downloading intl 0.17.0...
Downloading async 2.10.0...
Downloading dcli_core 1.34.1...
Downloading circular_buffer 0.11.0...
Downloading json_annotation 4.7.0...
Downloading js 0.6.5...
Changed 58 dependencies!
8 packages have newer versions incompatible with dependency constraints.
Try `dart pub outdated` for more information.
❯ ./dashito
Installing dashito command line application...
- Getting dependencies
Resolving dependencies... 
  basic_utils 3.9.4 (5.4.0 available)
  dcli 1.30.3 (1.35.4 available)
  dcli_core 1.34.1 (1.35.4 available)
  ffi 1.2.1 (2.0.1 available)
  posix 3.1.0 (4.1.0 available)
  scope 2.2.1 (3.0.0 available)
  settings_yaml 3.5.0 (4.0.0 available)
  win32 2.6.1 (3.0.1 available)
✔ Getting dependencies
✔ Bundling assets
- Compiling sidekick cli
Info: Compiling with sound null safety
✔ Compiling sidekick cli
A sidekick CLI to equip Dart/Flutter projects with custom tasks

Usage: dashito <command> [arguments]

Global options:
-h, --help    Print this usage information.

Available commands:
  analyze    Dart analyzes the whole project
  clean      Cleans the project
  dart       Calls dart
  deps       Gets dependencies for all packages
  sidekick   Manages the sidekick CLI

Run "dashito help <command>" for more information about a command.
❯ ./dashito sidekick plugins create -t install-only -n a_plugin
Formatted 1 file (0 changed) in 0.21 seconds.
❯ ./dashito sidekick plugins install -s path a_plugin
Installing a_plugin for dashito_options.yaml
Installer downloaded
Preparing a_plugin installer...
Executing installer a_plugin...
Installed a_plugin for dashito
❯ ./dashito
Installing dashito command line application...
- Getting dependencies
Resolving dependencies... 
  basic_utils 3.9.4 (5.4.0 available)
  dcli 1.30.3 (1.35.4 available)
  dcli_core 1.34.1 (1.35.4 available)
  ffi 1.2.1 (2.0.1 available)
  posix 3.1.0 (4.1.0 available)
  scope 2.2.1 (3.0.0 available)
  settings_yaml 3.5.0 (4.0.0 available)
  win32 2.6.1 (3.0.1 available)
✔ Getting dependencies
✔ Bundling assets
- Compiling sidekick cli
Info: Compiling with sound null safety
✔ Compiling sidekick cli
A sidekick CLI to equip Dart/Flutter projects with custom tasks

Usage: dashito <command> [arguments]

Global options:
-h, --help    Print this usage information.

Available commands:
  a-plugin   Sample command
  analyze    Dart analyzes the whole project
  clean      Cleans the project
  dart       Calls dart
  deps       Gets dependencies for all packages
  sidekick   Manages the sidekick CLI

Run "dashito help <command>" for more information about a command.
❯ ./dashito a-plugin
Greetings from PHNTM!
```

</details>