### PR TITLE
Add addFlutterSdkInitializer

### DIFF
--- a/sidekick_core/test/fake_sdk.dart
+++ b/sidekick_core/test/fake_sdk.dart
@@ -4,24 +4,28 @@ import 'package:test/test.dart';
 
 /// Creates a fake Flutter SDK in temp with a `flutter` executable that does
 /// nothing besides "downloading" a fake Dart executable that does also nothing
-Directory fakeFlutterSdk() {
-  final temp = Directory.systemTemp.createTempSync('fake_flutter');
-  addTearDown(() => temp.deleteSync(recursive: true));
+Directory fakeFlutterSdk({Directory? directory}) {
+  final Directory dir = directory ??
+      () {
+        final temp = Directory.systemTemp.createTempSync('fake_flutter');
+        addTearDown(() => temp.deleteSync(recursive: true));
+        return temp;
+      }();
 
-  final flutterExe = temp.file('bin/flutter')
+  final flutterExe = dir.file('bin/flutter')
     ..createSync(recursive: true)
     ..writeAsStringSync('''
 #!/bin/bash
 echo "fake Flutter executable"
 
 # Download dart SDK on execution
-mkdir -p ${temp.absolute.path}/bin/cache/dart-sdk/bin
+mkdir -p ${dir.absolute.path}/bin/cache/dart-sdk/bin
 # write into file
-printf "#!/bin/bash\\necho \\"fake embedded Dart executable\\"\\n" > ${temp.absolute.path}/bin/cache/dart-sdk/bin/dart
-chmod 755 ${temp.absolute.path}/bin/cache/dart-sdk/bin/dart
+printf "#!/bin/bash\\necho \\"fake embedded Dart executable\\"\\n" > ${dir.absolute.path}/bin/cache/dart-sdk/bin/dart
+chmod 755 ${dir.absolute.path}/bin/cache/dart-sdk/bin/dart
 ''');
   dcli.run('chmod 755 ${flutterExe.path}');
-  return temp;
+  return dir;
 }
 
 /// Creates a fake Dart SDK with a `dart` executable that does nothing

--- a/sidekick_core/test/flutter_command_test.dart
+++ b/sidekick_core/test/flutter_command_test.dart
@@ -5,19 +5,16 @@ import 'fake_sdk.dart';
 import 'init_test.dart';
 
 void main() {
-  test(
-    'flutter command works when flutterSdkPath is set',
-    () async {
-      await insideFakeProjectWithSidekick((dir) async {
-        final runner = initializeSidekick(
-          name: 'dash',
-          flutterSdkPath: fakeFlutterSdk().path,
-        );
-        runner.addCommand(FlutterCommand());
-        await runner.run(['flutter']);
-      });
-    },
-  );
+  test('flutter command works when flutterSdkPath is set', () async {
+    await insideFakeProjectWithSidekick((dir) async {
+      final runner = initializeSidekick(
+        name: 'dash',
+        flutterSdkPath: fakeFlutterSdk().path,
+      );
+      runner.addCommand(FlutterCommand());
+      await runner.run(['flutter']);
+    });
+  });
 
   test('flutter command fails when flutterSdkPath is not set', () async {
     await insideFakeProjectWithSidekick((dir) async {
@@ -33,6 +30,124 @@ void main() {
       } catch (e) {
         expect(e, isA<FlutterSdkNotSetException>());
       }
+    });
+  });
+
+  group('addFlutterSdkInitializer()', () {
+    test('initializer is executed before executing the flutter command',
+        () async {
+      await insideFakeProjectWithSidekick((dir) async {
+        final tempDir = Directory.systemTemp.createTempSync();
+        addTearDown(() => tempDir.deleteSync(recursive: true));
+        final runner = initializeSidekick(
+          name: 'dash',
+          flutterSdkPath: tempDir.path,
+        );
+        runner.addCommand(FlutterCommand());
+
+        bool called = false;
+        addFlutterSdkInitializer((sdkDir) {
+          fakeFlutterSdk(directory: tempDir);
+          return Future.sync(() {
+            called = true;
+          });
+        });
+        await runner.run(['flutter']);
+        expect(called, isTrue);
+      });
+    });
+
+    test(
+        'multiple initializers are executed before executing the flutter command',
+        () async {
+      await insideFakeProjectWithSidekick((dir) async {
+        final tempDir = Directory.systemTemp.createTempSync();
+        addTearDown(() => tempDir.deleteSync(recursive: true));
+        final runner = initializeSidekick(
+          name: 'dash',
+          flutterSdkPath: tempDir.path,
+        );
+        runner.addCommand(FlutterCommand());
+
+        bool called1 = false;
+        addFlutterSdkInitializer((sdkDir) {
+          // async
+          fakeFlutterSdk(directory: tempDir);
+          return Future.sync(() {
+            called1 = true;
+          });
+        });
+
+        bool called2 = false;
+        addFlutterSdkInitializer((sdkDir) {
+          // sync
+          called2 = true;
+        });
+
+        await runner.run(['flutter']);
+        expect(called1, isTrue);
+        expect(called2, isTrue);
+      });
+    });
+
+    test('The same initializer is only added once', () async {
+      await insideFakeProjectWithSidekick((dir) async {
+        final tempDir = Directory.systemTemp.createTempSync();
+        addTearDown(() => tempDir.deleteSync(recursive: true));
+        final runner = initializeSidekick(
+          name: 'dash',
+          flutterSdkPath: tempDir.path,
+        );
+        runner.addCommand(FlutterCommand());
+
+        int called = 0;
+        void initializer(Directory path) {
+          called++;
+        }
+
+        addFlutterSdkInitializer(initializer);
+        addFlutterSdkInitializer(initializer);
+
+        await runner.run(['flutter']).onError((error, stackTrace) {
+          // ignore
+        });
+        expect(called, 1);
+      });
+    });
+
+    test('Removing an initializer, prevents execution', () async {
+      await insideFakeProjectWithSidekick((dir) async {
+        final tempDir = Directory.systemTemp.createTempSync();
+        addTearDown(() => tempDir.deleteSync(recursive: true));
+        final runner = initializeSidekick(
+          name: 'dash',
+          flutterSdkPath: tempDir.path,
+        );
+        runner.addCommand(FlutterCommand());
+
+        int called = 0;
+        void initializer(Directory path) {
+          called++;
+        }
+
+        final remove = addFlutterSdkInitializer(initializer);
+
+        await runner.run(['flutter']).onError((error, stackTrace) {
+          // ignore
+        });
+        expect(called, 1);
+
+        await runner.run(['flutter']).onError((error, stackTrace) {
+          // ignore
+        });
+        expect(called, 2);
+
+        remove();
+        await runner.run(['flutter']).onError((error, stackTrace) {
+          // ignore
+        });
+        expect(called, 2);
+      });
     });
   });
 }


### PR DESCRIPTION
Currently, when using the [flutterw_sidekick_plugin](https://github.com/passsy/flutterw_sidekick_plugin), there is a problem when running `flutter()` for the first time. Because we only define `flutterSdkPath`, it may happen that the Flutter SDK is not yet downloaded. This leads to an error that can only be resolved by manually calling `./flutterw`.

```
Unhandled exception:
SdkNotFoundException{message: Dart or Flutter SDK set to '/Users/pascalwelsch/Downloads/vgv_start/.flutter', but that directory doesn't exist. Please fix the path in `initializeSidekick` (dartSdkPath/flutterSdkPath). Note that relative sdk paths are resolved relative to the project root, which in this case is '/Users/pascalwelsch/Downloads/vgv_start'.}
#0      _resolveSdkPath (package:sidekick_core/sidekick_core.dart:247)
#1      initializeSidekick (package:sidekick_core/sidekick_core.dart:83)
#2      runVgs (package:vgs_sidekick/vgs_sidekick.dart:12)
#3      main (file:///Users/pascalwelsch/Downloads/vgv_start/packages/vgs_sidekick/bin/main.dart:4)
#4      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:295)
#5      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192)
```

The new `addFlutterSdkInitializer()` API allows custom SDK wrappers to do work (like downloading) before the `flutter` executable is called.