### PR TITLE
Improve error message when file doesn't exist

### DIFF
--- a/sidekick_vault/lib/src/vault.dart
+++ b/sidekick_vault/lib/src/vault.dart
@@ -60,7 +60,11 @@ class SidekickVault {
           '"$filename" does not';
     }
     if (!file.existsSync()) {
-      throw "${file.path} does not exist in vault";
+      if (file.isAbsolute) {
+        throw "${file.path} does not exist";
+      } else {
+        throw "${file.path} does not exist in ${Directory.current.path}";
+      }
     }
     return gpgEncrypt(file, _passphrase!, output: outFile);
   }

--- a/sidekick_vault/test/vault_command_test.dart
+++ b/sidekick_vault/test/vault_command_test.dart
@@ -135,10 +135,25 @@ void main() {
         ),
       );
     });
-    test('throws for non-files', () {
+    test('throws for non-files (absolute path)', () {
       expect(
         () => withEnvironment(
           () => runner.run(['vault', 'encrypt', 'unknown.gpg']),
+          environment: {'FLG_VAULT_PASSPHRASE': 'asdfasdf'},
+        ),
+        throwsA(
+          isA<String>().having(
+            (it) => it,
+            'error',
+            contains('unknown.gpg does not exist in'),
+          ),
+        ),
+      );
+    });
+    test('throws for non-files (relative path)', () {
+      expect(
+        () => withEnvironment(
+          () => runner.run(['vault', 'encrypt', '/root/unknown.gpg']),
           environment: {'FLG_VAULT_PASSPHRASE': 'asdfasdf'},
         ),
         throwsA(


### PR DESCRIPTION
Screwing up the file path for `vault encrypt` was showing a wrong error message:

```
Unhandled exception:
random.csv does not exist in vault
#0      SidekickVault.saveFile (package:sidekick_vault/src/vault.dart:63)
#1      _EncryptCommand.run (package:sidekick_vault/src/commands/vault_command.dart:75)
#2      CommandRunner.runCommand (package:args/command_runner.dart:209)
#3      CommandRunner.run.<anonymous closure> (package:args/command_runner.dart:119)
#4      new Future.sync (dart:async/future.dart:302)
#5      CommandRunner.run (package:args/command_runner.dart:119)
#6      SidekickCommandRunner.run (package:sidekick_core/sidekick_core.dart:128)
#7      runNoa (package:noa_sidekick/noa_sidekick.dart:65)
#8      main (file:///Users/stevendzionara/noa-frontend/packages/noa_sidekick/bin/main.dart:4)
#9      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:295)
#10     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192)
```

`random.csv does not exist in vault` is wrong, because the file has never been in vault, it was about to be imported.

The new error `random.csv does not exist in <cwd>` is much more helpful