### PR TITLE
Constrain dcli in every package

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,5 @@ jobs:
         run: |
              dart pub global activate dartdoc 5.0.1
              cd "${{ matrix.package }}" && $HOME/.pub-cache/bin/dartdoc
-
-      # TODO set dcli constraints
-      #- name: Verify package completeness
-      #  run: cd "${{ matrix.package }}" && dart pub publish -n
+      - name: Verify package completeness
+        run: cd "${{ matrix.package }}" && dart pub publish -n

--- a/sidekick_plugin_installer/pubspec.yaml
+++ b/sidekick_plugin_installer/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   analyzer: '>=4.0.0 <6.0.0'
-  dcli: # version provided by sidekick_core
+  dcli: ^1.15.0
   sidekick_core: '>=0.7.0 <1.0.0'
 
 dev_dependencies:

--- a/sidekick_vault/pubspec.yaml
+++ b/sidekick_vault/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   actions_toolkit_dart: ^0.5.0
-  dcli: # provided by sidekick_core
+  dcli: ^1.15.0
   sidekick_core: '>=0.7.0 <1.0.0'
 
 dev_dependencies:


### PR DESCRIPTION
It will be further constrained by `sidekick_core`

This allows us to test for publish warnings