### PR TITLE
Minimize stdout when auto compiling the cli

### DIFF
--- a/sidekick/test/recompile_test.dart
+++ b/sidekick/test/recompile_test.dart
@@ -60,12 +60,14 @@ void main() {
         );
         final stdout = await updateProcess.stdoutStream().join('\n');
         printOnFailure(stdout);
-        printOnFailure(await updateProcess.stderrStream().join('\n'));
+        final stderr = await updateProcess.stderrStream().join('\n');
+        printOnFailure(stderr);
         updateProcess.shouldExit(0);
-        expect(stdout, contains('Installing dashi command line application'));
-        expect(stdout, contains('Getting dependencies'));
-        expect(stdout, contains('Bundling assets'));
-        expect(stdout, contains('Compiling sidekick cli'));
+        expect(stderr, contains('Installing dashi command line application'));
+        expect(stderr, contains('Getting dependencies'));
+        expect(stderr, contains('Bundling assets'));
+        expect(stderr, contains('Compiling sidekick cli'));
+        expect(stderr, contains('Success!'));
       },
       timeout: const Timeout(Duration(minutes: 5)),
     );

--- a/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
@@ -155,12 +155,16 @@ Directory _getPackageRootDirForHostedOrGitSource(ArgResults args) {
 
   final progress = dcli.Progress(
     dcli.devNull,
-    stderr: print,
     // this parameter has a typo in dcli and actually is captureStdOut
     captureStdin: true,
     captureStderr: true,
   );
-  sidekickDartRuntime.dart(pubGlobalActivateArgs, progress: progress);
+  try {
+    sidekickDartRuntime.dart(pubGlobalActivateArgs, progress: progress);
+  } catch (e) {
+    print(progress.lines.join('\n'));
+    rethrow;
+  }
 
   // TODO We should definitely do this in a less hacky way
   // Our goal is to get the cache directory of the package.


### PR DESCRIPTION
Remove stdout from `dart pub get` and `dart compile exe` unless they exit with non-zero exit code.

### Before
<img width="486" alt="Screen-Shot-2022-11-14-14-58-51 23" src="https://user-images.githubusercontent.com/1096485/201678573-10359f01-62b2-448d-9d09-cdbd21bc08dc.png">

### After
<img width="337" alt="Screen-Shot-2022-11-14-14-54-33 31" src="https://user-images.githubusercontent.com/1096485/201678392-828caf01-9503-47b2-ae37-4ffc02decdbe.png">
