### PR TITLE
Make folder creation sync

### DIFF
--- a/sidekick_vault/tool/install.dart
+++ b/sidekick_vault/tool/install.dart
@@ -50,7 +50,7 @@ final SidekickVault vault = SidekickVault(
 void _createVaultFolder(SidekickPackage package) {
   final folder = package.root.directory('vault');
   if (!folder.existsSync()) {
-    folder.create();
+    folder.createSync();
   }
 
   final readme = folder.file('README.md');


### PR DESCRIPTION
I just discovered that the `README` could not be created because the folder was not yet created. 

Dumb mistake, I did not await the future 

![](https://media3.giphy.com/media/14aUO0Mf7dWDXW/giphy.gif?cid=ecf05e47tr7yg88mbpmb08lhry4p706482aikcrrj2b0gca6&rid=giphy.gif&ct=g)