### PR TITLE
Add `--version` flag to print current sidekick version

### DIFF
--- a/sidekick/lib/sidekick.dart
+++ b/sidekick/lib/sidekick.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:sidekick/src/init/init_command.dart';
 import 'package:sidekick/src/plugins/plugins_command.dart';
-import 'package:sidekick_core/sidekick_core.dart' as skc;
+import 'package:sidekick_core/sidekick_core.dart' as core;
 import 'package:sidekick_core/sidekick_core.dart' show Version;
 
 /// The version of package:sidekick
@@ -38,7 +38,7 @@ class _SidekickCommandRunner extends CommandRunner {
   Future<void> run(Iterable<String> args) async {
     final parsedArgs = parse(args);
     if (parsedArgs['version'] == true) {
-      print('sidekick: $version\nsidekick_core: ${skc.version}');
+      print('sidekick: $version\nsidekick_core: ${core.version}');
       return;
     }
     return super.run(args);

--- a/sidekick/lib/sidekick.dart
+++ b/sidekick/lib/sidekick.dart
@@ -3,6 +3,12 @@ import 'dart:io';
 import 'package:args/command_runner.dart';
 import 'package:sidekick/src/init/init_command.dart';
 import 'package:sidekick/src/plugins/plugins_command.dart';
+import 'package:sidekick_core/sidekick_core.dart' as skc;
+import 'package:sidekick_core/sidekick_core.dart' show Version;
+
+/// The version of package:sidekick
+// DO NOT MANUALLY EDIT THIS VERSION, instead run `sk bump-version sidekick`
+final Version version = Version.parse('0.7.2');
 
 /// See the [README](https://github.com/phntmxyz/sidekick/blob/main/sidekick/README.md)
 /// for more information on sidekick
@@ -20,7 +26,23 @@ Future<void> main(List<String> args) async {
 }
 
 class _SidekickCommandRunner extends CommandRunner {
-  _SidekickCommandRunner() : super('sidekick', _desc);
+  _SidekickCommandRunner() : super('sidekick', _desc) {
+    argParser.addFlag(
+      'version',
+      negatable: false,
+      help: 'Print version information.',
+    );
+  }
+
+  @override
+  Future<void> run(Iterable<String> args) async {
+    final parsedArgs = parse(args);
+    if (parsedArgs['version'] == true) {
+      print('sidekick: $version\nsidekick_core: ${skc.version}');
+      return;
+    }
+    return super.run(args);
+  }
 
   static const _desc =
       'Generator for a sidekick command line application (cli)';

--- a/sidekick/test/init_test.dart
+++ b/sidekick/test/init_test.dart
@@ -1,9 +1,7 @@
-import 'dart:async';
-
 import 'package:sidekick/sidekick.dart';
 import 'package:sidekick/src/util/dcli_ask_validators.dart';
 import 'package:sidekick_core/sidekick_core.dart' hide version;
-import 'package:sidekick_core/sidekick_core.dart' as skc;
+import 'package:sidekick_core/sidekick_core.dart' as core;
 import 'package:sidekick_test/sidekick_test.dart';
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
@@ -31,7 +29,7 @@ void main() {
     final process =
         await cli.run(['--version'], workingDirectory: Directory.current);
     final output = await process.stdoutStream().join('\n');
-    expect(output, 'sidekick: $version\nsidekick_core: ${skc.version}');
+    expect(output, 'sidekick: $version\nsidekick_core: ${core.version}');
   });
 
   group('sidekick init - argument validation', () {

--- a/sidekick/test/init_test.dart
+++ b/sidekick/test/init_test.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
+import 'package:sidekick/sidekick.dart';
 import 'package:sidekick/src/util/dcli_ask_validators.dart';
-import 'package:sidekick_core/sidekick_core.dart';
+import 'package:sidekick_core/sidekick_core.dart' hide version;
+import 'package:sidekick_core/sidekick_core.dart' as skc;
 import 'package:sidekick_test/sidekick_test.dart';
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
@@ -8,6 +12,28 @@ import 'templates/templates.dart';
 import 'util/cli_runner.dart';
 
 void main() {
+  test('version is correct', () {
+    final pubspec = File('pubspec.yaml');
+    expect(pubspec.existsSync(), isTrue);
+
+    final yaml = pubspec.readAsStringSync();
+
+    final packageName = RegExp(r'name:\s*(.*)').firstMatch(yaml)!.group(1)!;
+    final packageVersion =
+        Version.parse(RegExp(r'version:\s*(.*)').firstMatch(yaml)!.group(1)!);
+
+    expect(packageName, 'sidekick');
+    expect(packageVersion, version);
+  });
+
+  test('--version flag prints sidekick and sidekick_core versions', () async {
+    final cli = await buildSidekickCli();
+    final process =
+        await cli.run(['--version'], workingDirectory: Directory.current);
+    final output = await process.stdoutStream().join('\n');
+    expect(output, 'sidekick: $version\nsidekick_core: ${skc.version}');
+  });
+
   group('sidekick init - argument validation', () {
     test(
       'throws when entrypointDirectory does not exist',

--- a/sidekick_core/lib/sidekick_core.dart
+++ b/sidekick_core/lib/sidekick_core.dart
@@ -111,7 +111,7 @@ class SidekickCommandRunner<T> extends CommandRunner<T> {
     argParser.addFlag(
       'version',
       negatable: false,
-      help: 'Reports the sidekick version of this CLI.',
+      help: 'Print the sidekick version of this CLI.',
     );
   }
 
@@ -142,7 +142,7 @@ class SidekickCommandRunner<T> extends CommandRunner<T> {
     final unmount = mount();
     try {
       final parsedArgs = parse(args);
-      if ((parsedArgs['version'] as bool?) ?? false) {
+      if (parsedArgs['version'] == true) {
         print('$cliName is using sidekick version $version');
         return null;
       }

--- a/sidekick_core/lib/sidekick_core.dart
+++ b/sidekick_core/lib/sidekick_core.dart
@@ -107,7 +107,13 @@ class SidekickCommandRunner<T> extends CommandRunner<T> {
     required this.workingDirectory,
     this.flutterSdk,
     this.dartSdk,
-  }) : super(cliName, description);
+  }) : super(cliName, description) {
+    argParser.addFlag(
+      'version',
+      negatable: false,
+      help: 'Reports the sidekick version of this CLI.',
+    );
+  }
 
   final Repository repository;
   final DartPackage? mainProject;
@@ -135,6 +141,12 @@ class SidekickCommandRunner<T> extends CommandRunner<T> {
 
     final unmount = mount();
     try {
+      final parsedArgs = parse(args);
+      if ((parsedArgs['version'] as bool?) ?? false) {
+        print('$cliName is using sidekick version $version');
+        return null;
+      }
+
       final result = await super.run(args);
       return result;
     } finally {

--- a/sidekick_core/test/init_test.dart
+++ b/sidekick_core/test/init_test.dart
@@ -21,6 +21,26 @@ void main() {
     expect(packageVersion, version);
   });
 
+  test('--version flag prints version and does not execute command', () async {
+    final printLog = <String>[];
+    // override print to verify output
+    final spec = ZoneSpecification(
+      print: (_, __, ___, line) => printLog.add(line),
+    );
+    await Zone.current.fork(specification: spec).run(() async {
+      await insideFakeProjectWithSidekick((dir) async {
+        final runner = initializeSidekick(name: 'dash');
+        bool called = false;
+        runner.addCommand(
+          _DelegatedCommand(name: 'inside', block: () => called = true),
+        );
+        await runner.run(['inside', '--version']);
+        expect(called, isFalse);
+        expect(printLog, contains('dash is using sidekick version $version'));
+      });
+    });
+  });
+
   group('mainProject', () {
     test('mainProject only works in SidekickCommandRunner scope', () {
       expect(

--- a/sidekick_core/test/init_test.dart
+++ b/sidekick_core/test/init_test.dart
@@ -27,18 +27,22 @@ void main() {
     final spec = ZoneSpecification(
       print: (_, __, ___, line) => printLog.add(line),
     );
-    await Zone.current.fork(specification: spec).run(() async {
-      await insideFakeProjectWithSidekick((dir) async {
-        final runner = initializeSidekick(name: 'dash');
-        bool called = false;
-        runner.addCommand(
-          _DelegatedCommand(name: 'inside', block: () => called = true),
-        );
-        await runner.run(['inside', '--version']);
-        expect(called, isFalse);
-        expect(printLog, contains('dash is using sidekick version $version'));
-      });
-    });
+
+    await runZoned(
+      () async {
+        await insideFakeProjectWithSidekick((dir) async {
+          final runner = initializeSidekick(name: 'dash');
+          bool called = false;
+          runner.addCommand(
+            _DelegatedCommand(name: 'inside', block: () => called = true),
+          );
+          await runner.run(['inside', '--version']);
+          expect(called, isFalse);
+          expect(printLog, contains('dash is using sidekick version $version'));
+        });
+      },
+      zoneSpecification: spec,
+    );
   });
 
   group('mainProject', () {

--- a/sk_sidekick/lib/sk_sidekick.dart
+++ b/sk_sidekick/lib/sk_sidekick.dart
@@ -2,7 +2,8 @@ import 'dart:async';
 
 import 'package:sidekick_core/sidekick_core.dart';
 import 'package:sk_sidekick/src/commands/bump_version_command.dart';
-import 'package:sk_sidekick/src/release/core_bundled_version_bump.dart';
+import 'package:sk_sidekick/src/release/sidekick_bundled_version_bump.dart';
+import 'package:sk_sidekick/src/release/sidekick_core_bundled_version_bump.dart';
 import 'package:sk_sidekick/src/sk_project.dart';
 
 late SkProject skProject;
@@ -20,7 +21,9 @@ Future<void> runSk(List<String> args) async {
     ..addCommand(DepsCommand(exclude: [...testPackages]))
     ..addCommand(DartAnalyzeCommand())
     ..addCommand(
-      BumpVersionCommand()..addModification(coreBundledVersionBump),
+      BumpVersionCommand()
+        ..addModification(sidekickCoreBundledVersionBump)
+        ..addModification(sidekickBundledVersionBump),
     )
     ..addCommand(SidekickCommand());
 

--- a/sk_sidekick/lib/src/release/sidekick_bundled_version_bump.dart
+++ b/sk_sidekick/lib/src/release/sidekick_bundled_version_bump.dart
@@ -1,0 +1,24 @@
+import 'package:sidekick_core/sidekick_core.dart';
+import 'package:sk_sidekick/sk_sidekick.dart';
+
+/// Updates the version in sidekick/lib/sidekick_core.dart
+void sidekickBundledVersionBump(
+  DartPackage package,
+  Version oldVersion,
+  Version newVersion,
+) {
+  if (package != skProject.sidekickPackage) {
+    return;
+  }
+
+  // Update version for sidekick package
+  final sidekickFile = skProject.sidekickPackage.root.file('lib/sidekick.dart');
+  sidekickFile.replaceSectionWith(
+    startTag: 'final Version version = Version.parse(',
+    endTag: ');',
+    content: "'$newVersion'",
+  );
+  if (!sidekickFile.readAsStringSync().contains(newVersion.toString())) {
+    throw 'Failed to update version in ${sidekickFile.path}';
+  }
+}

--- a/sk_sidekick/lib/src/release/sidekick_core_bundled_version_bump.dart
+++ b/sk_sidekick/lib/src/release/sidekick_core_bundled_version_bump.dart
@@ -2,7 +2,7 @@ import 'package:sidekick_core/sidekick_core.dart';
 import 'package:sk_sidekick/sk_sidekick.dart';
 
 /// Updates the version in sidekick_core/lib/sidekick_core.dart
-void coreBundledVersionBump(
+void sidekickCoreBundledVersionBump(
   DartPackage package,
   Version oldVersion,
   Version newVersion,
@@ -11,7 +11,7 @@ void coreBundledVersionBump(
     return;
   }
 
-  // Update version for core package
+  // Update version for sidekick_core package
   final coreFile =
       skProject.sidekickCorePackage.root.file('lib/sidekick_core.dart');
   coreFile.replaceSectionWith(


### PR DESCRIPTION
Fixes #127

- [x] print version of generated cli 
- [x] print version of global `sidekick` cli