### PR TITLE
Simplify install script path pattern check

### DIFF
--- a/sidekick_plugin_installer/lib/src/plugin_context.dart
+++ b/sidekick_plugin_installer/lib/src/plugin_context.dart
@@ -108,7 +108,7 @@ class PluginContext {
     final toolInstallScript = Platform.script;
     // build/plugins/<name>/tool/install.dart
     final relevantPath = toolInstallScript.pathSegments.takeLast(5).join('/');
-    final expectedPathPattern = RegExp('build/plugins/[^/]+/tool/install.dart');
+    final expectedPathPattern = RegExp('[^/]+/tool/install.dart');
 
     if (!expectedPathPattern.hasMatch(relevantPath)) {
       throw 'PluginContext.buildPlugin can only be accessed inside of a '

--- a/sidekick_plugin_installer/lib/src/plugin_context.dart
+++ b/sidekick_plugin_installer/lib/src/plugin_context.dart
@@ -106,11 +106,8 @@ class PluginContext {
   /// otherwise it throws
   static DartPackage get installerPlugin {
     final toolInstallScript = Platform.script;
-    // build/plugins/<name>/tool/install.dart
-    final relevantPath = toolInstallScript.pathSegments.takeLast(5).join('/');
-    final expectedPathPattern = RegExp('[^/]+/tool/install.dart');
-
-    if (!expectedPathPattern.hasMatch(relevantPath)) {
+    final pathEnd = toolInstallScript.pathSegments.takeLast(2).join('/');
+    if (pathEnd != 'tool/install.dart') {
       throw 'PluginContext.buildPlugin can only be accessed inside of a '
           "plugin's tool/install.dart";
     }


### PR DESCRIPTION
This allows debugging of plugin installers, by manually executing `install.dart` without calling sidekick install.