### PR TITLE
Refactor `VersionChecker` to return null instead of throwing in edge cases

### DIFF
--- a/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
@@ -76,12 +76,12 @@ class InstallPluginCommand extends Command {
         case 'path':
           final dir = Directory(packageNameOrGitUrlOrLocalPath);
           if (!dir.existsSync()) {
-            throw "Directory at ${dir.absolute.path} does not exist";
+            error("Directory at ${dir.absolute.path} does not exist");
           }
 
           final localPackage = DartPackage.fromDirectory(dir);
           if (localPackage == null) {
-            throw "Directory at ${dir.absolute.path} is not a dart package";
+            error("Directory at ${dir.absolute.path} is not a dart package");
           }
 
           env['SIDEKICK_PLUGIN_NAME'] = localPackage.name;
@@ -143,6 +143,12 @@ class InstallPluginCommand extends Command {
 
     final pluginInstallerProtocolVersion =
         pluginVersionChecker.getResolvedVersion('sidekick_plugin_installer');
+
+    if (pluginInstallerProtocolVersion is! Version) {
+      error("The plugin you're trying to install isn't a valid sidekick plugin "
+          "because it doesn't have a dependency on sidekick_plugin_installer.");
+    }
+
     final supportedInstallerVersions = VersionRange(
       // update when sidekick_core removes support for old sidekick_plugin_installer protocol
       min: Version.none,
@@ -153,11 +159,11 @@ class InstallPluginCommand extends Command {
     // old CLIs shouldn't install new plugins
     if (!supportedInstallerVersions.allows(pluginInstallerProtocolVersion)) {
       if (pluginInstallerProtocolVersion < supportedInstallerVersions.max!) {
-        throw "The plugin doesn't support your CLI's version.\n"
-            'Please run ${yellow('$cliName sidekick update')} to update your CLI.';
+        error("The plugin doesn't support your CLI's version.\n"
+            'Please run ${yellow('$cliName sidekick update')} to update your CLI.');
       } else {
-        throw 'The plugin is too old to be installed to your CLI '
-            'because it depends on an outdated version of sidekick_plugin_installer.';
+        error('The plugin is too old to be installed to your CLI '
+            'because it depends on an outdated version of sidekick_plugin_installer.');
       }
     }
 
@@ -172,8 +178,8 @@ class InstallPluginCommand extends Command {
         case 'hosted':
           break;
         case 'git':
-          throw "The plugin's outdated sidekick_plugin_installer dependency "
-              "doesn't allow installation from git.";
+          error("The plugin's outdated sidekick_plugin_installer dependency "
+              "doesn't allow installation from git.");
         default:
           throw StateError('unreachable');
       }
@@ -253,10 +259,10 @@ Directory _getPackageRootDirForHostedOrGitSource(ArgResults args) {
         'sidekick CLI in its pubspec.yaml. Then, execute the entrypoint of '
         'your sidekick CLI again to download the new Dart SDK version.';
     if (progress.lines.contains('Could not find an option named "git-path".')) {
-      throw parameterNotAvailableErrorMessage('git-path', '2.17');
+      error(parameterNotAvailableErrorMessage('git-path', '2.17'));
     }
     if (progress.lines.contains('Could not find an option named "git-ref".')) {
-      throw parameterNotAvailableErrorMessage('git-ref', '2.19');
+      error(parameterNotAvailableErrorMessage('git-ref', '2.19'));
     }
 
     print(progress.lines.join('\n'));

--- a/sidekick_core/lib/src/commands/update_command.dart
+++ b/sidekick_core/lib/src/commands/update_command.dart
@@ -34,7 +34,7 @@ class UpdateCommand extends Command {
     // with, that sidekick_core version is written into the CLI's pubspec.yaml
     // at the path ['sidekick', 'cli_version']
     final currentSidekickCliVersion = versionChecker
-            .getMinimumVersionConstraintOrNull(['sidekick', 'cli_version']) ??
+            .getMinimumVersionConstraint(['sidekick', 'cli_version']) ??
         Version.none;
 
     if (versionToInstall <= currentSidekickCliVersion) {

--- a/sidekick_core/test/version_checker_test.dart
+++ b/sidekick_core/test/version_checker_test.dart
@@ -112,17 +112,16 @@ dependencies:
           ),
         );
       });
+    });
 
+    group('returns null when', () {
       test('path does not exist at all', () {
         pubspecYamlFile.writeAsStringSync('''
 name: dashi
 ''');
         expect(
-          () => versionChecker
-              .getMinimumVersionConstraint(['dependencies', 'foo']),
-          throwsA(
-            "Couldn't read path '['dependencies', 'foo']' from yaml file '${pubspecYamlFile.path}'",
-          ),
+          versionChecker.getMinimumVersionConstraint(['dependencies', 'foo']),
+          isNull,
         );
       });
 
@@ -132,11 +131,8 @@ name: dashi
 dependencies:
 ''');
         expect(
-          () => versionChecker
-              .getMinimumVersionConstraint(['dependencies', 'foo']),
-          throwsA(
-            "Couldn't read path '['dependencies', 'foo']' from yaml file '${pubspecYamlFile.path}'",
-          ),
+          versionChecker.getMinimumVersionConstraint(['dependencies', 'foo']),
+          isNull,
         );
       });
     });


### PR DESCRIPTION
Fixes #142
 
## Breaking Changes 
- Deprecate `VersionChecker.getMinimumVersionConstraintOrNull` in favor of `VersionChecker.getMinimumVersionConstraint`
- `VersionChecker.getMinimumVersionConstraint` returns null when `pubspec.yaml` doesn't contain the dependency
- `VersionChecker.getResolvedVersion` returns null when `pubspec.lock` doesn't contain the dependency