### PR TITLE
[Refactor] Use migrations steps for sidekick update

### DIFF
--- a/sidekick/lib/src/init/init_command.dart
+++ b/sidekick/lib/src/init/init_command.dart
@@ -4,6 +4,7 @@ import 'package:sidekick/src/init/name_suggester.dart';
 import 'package:sidekick/src/util/dcli_ask_validators.dart';
 import 'package:sidekick/src/util/directory_extension.dart';
 import 'package:sidekick_core/sidekick_core.dart';
+import 'package:sidekick_core/sidekick_core.dart' as core;
 
 class InitCommand extends Command {
   @override
@@ -186,7 +187,7 @@ class InitCommand extends Command {
           .any((package) => package.isFlutterPackage),
       entrypointLocation: entrypoint,
       packageLocation: cliPackage,
-      sidekickCliVersion: version,
+      sidekickCliVersion: core.version,
     );
     SidekickTemplate().generate(props);
 

--- a/sidekick_core/lib/src/template/sidekick_package.template.dart
+++ b/sidekick_core/lib/src/template/sidekick_package.template.dart
@@ -79,32 +79,31 @@ class SidekickTemplateProperties {
   final Directory packageLocation;
 
   /// When there's a flutter package that requires a flutter sdk
-  final bool shouldSetFlutterSdkPath;
+  final bool? shouldSetFlutterSdkPath;
 
   /// When the dart package is located in root of the repo
-  final bool isMainProjectRoot;
+  final bool? isMainProjectRoot;
 
   /// true when a /packages directory exists
-  final bool hasNestedPackagesPath;
+  final bool? hasNestedPackagesPath;
 
   /// Path to main project, relative from repo root
   final String? mainProjectPath;
 
-  /// The version of the generated sidekick CLI
+  /// The current version of sidekick_core which includes the project templates
   ///
-  /// This is set to the version of sidekick_core because sidekick_core contains
-  /// the template used for generation of the CLI.
-  final Version sidekickCliVersion;
+  /// This version should be written to pubspec.yaml as sidekick.cli_version
+  final Version? sidekickCliVersion;
 
   const SidekickTemplateProperties({
     required this.name,
     required this.entrypointLocation,
     required this.packageLocation,
-    required this.mainProjectPath,
-    required this.shouldSetFlutterSdkPath,
-    required this.isMainProjectRoot,
-    required this.hasNestedPackagesPath,
-    required this.sidekickCliVersion,
+    this.sidekickCliVersion,
+    this.mainProjectPath,
+    this.shouldSetFlutterSdkPath,
+    this.isMainProjectRoot,
+    this.hasNestedPackagesPath,
   });
 }
 
@@ -120,7 +119,7 @@ Future<void> main(List<String> arguments) async {
   }
 
   String cliProjectDart() {
-    if (isMainProjectRoot) {
+    if (isMainProjectRoot!) {
       return '''
 import 'package:sidekick_core/sidekick_core.dart';
 
@@ -139,13 +138,13 @@ class ${name.pascalCase}Project extends DartPackage {
   List<DartPackage>? _packages;
   List<DartPackage> get allPackages {
     return _packages ??= root
-        ${hasNestedPackagesPath ? ".directory('$mainProjectPath')" : ''}
+        ${hasNestedPackagesPath! ? ".directory('$mainProjectPath')" : ''}
         .directory('packages')
         .listSync()
         .whereType<Directory>()
         .mapNotNull((it) => DartPackage.fromDirectory(it))
         .toList()
-      ${isMainProjectRoot ? '..add(this)' : ''};
+      ${isMainProjectRoot! ? '..add(this)' : ''};
   }
 }
 ''';
@@ -164,13 +163,13 @@ class ${name.pascalCase}Project {
   List<DartPackage>? _packages;
   List<DartPackage> get allPackages {
     return _packages ??= root
-        ${hasNestedPackagesPath ? ".directory('$mainProjectPath')" : ''}
+        ${hasNestedPackagesPath! ? ".directory('$mainProjectPath')" : ''}
         .directory('packages')
         .listSync()
         .whereType<Directory>()
         .mapNotNull((it) => DartPackage.fromDirectory(it))
         .toList()
-        ${isMainProjectRoot ? '..add(this)' : ''};
+        ${isMainProjectRoot! ? '..add(this)' : ''};
   }
 }
 
@@ -180,7 +179,7 @@ class ${name.pascalCase}Project {
 
   String cliSidekickDart() {
     final commands = [
-      if (shouldSetFlutterSdkPath) 'FlutterCommand()',
+      if (shouldSetFlutterSdkPath!) 'FlutterCommand()',
       'DartCommand()',
       'DepsCommand()',
       'CleanCommand()',
@@ -205,7 +204,7 @@ Future<void> run${name.pascalCase}(List<String> args) async {
   final runner = initializeSidekick(
     name: '${name.snakeCase}',
     ${mainProjectPath != null ? "mainProjectPath: '$mainProjectPath'," : ''}
-    ${shouldSetFlutterSdkPath ? 'flutterSdkPath: systemFlutterSdkPath(),' : 'dartSdkPath: systemDartSdkPath(),'}
+    ${shouldSetFlutterSdkPath! ? 'flutterSdkPath: systemFlutterSdkPath(),' : 'dartSdkPath: systemDartSdkPath(),'}
   );
 
   ${name.snakeCase}Project = ${name.pascalCase}Project($projectRoot);
@@ -270,7 +269,7 @@ dev_dependencies:
 
 # generated code, do not edit this manually
 sidekick:
-  cli_version: ${sidekickCliVersion.canonicalizedVersion}
+  cli_version: ${sidekickCliVersion!.canonicalizedVersion}
 ''';
   }
 }

--- a/sidekick_core/lib/src/update/migration.dart
+++ b/sidekick_core/lib/src/update/migration.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:dartx/dartx.dart';
+import 'package:dcli/dcli.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+class MigrationStep {
+  /// The version after which this migration should be executed.
+  final Version oldVersion;
+
+  /// A human readable name for this migration.
+  final String name;
+
+  /// The code to execute for this migration.
+  final FutureOr<void> Function(MigrationContext) block;
+
+  const MigrationStep(
+    this.block, {
+    required this.name,
+    required this.oldVersion,
+  });
+}
+
+/// Information about the full migration while doing a migration.
+class MigrationContext {
+  final MigrationStep step;
+  final Version from;
+  final Version to;
+
+  Object? _exception;
+  Object? get exception => _exception;
+
+  StackTrace? _stackTrace;
+  StackTrace? get stackTrace => _stackTrace;
+
+  MigrationContext({
+    required this.step,
+    required this.from,
+    required this.to,
+  });
+}
+
+Future<void> migrate({
+  required Version from,
+  required Version to,
+  required List<MigrationStep> migrations,
+  FutureOr<MigrationErrorHandling> Function(MigrationContext)? onMigrationError,
+}) async {
+  final migrationsToExecute = migrations
+      .where((m) => m.oldVersion > from && m.oldVersion < to)
+      .sortedBy((m) => m.oldVersion)
+      .toList();
+
+  for (final migration in migrationsToExecute) {
+    final context = MigrationContext(step: migration, from: from, to: to);
+    bool retry = true;
+    while (retry) {
+      retry = false;
+      try {
+        await migration.block(context);
+      } catch (e, s) {
+        context._exception = e;
+        context._stackTrace = s;
+        if (onMigrationError == null) {
+          printerr(
+              'Migration ${migration.name} (${migration.oldVersion}) failed:');
+          printerr(e.toString());
+          printerr(s.toString());
+        }
+        final handling =
+            onMigrationError?.call(context) ?? MigrationErrorHandling.skip;
+        switch (handling) {
+          case MigrationErrorHandling.skip:
+            continue;
+          case MigrationErrorHandling.abort:
+            rethrow;
+          case MigrationErrorHandling.retry:
+            retry = true;
+        }
+      }
+    }
+  }
+}
+
+enum MigrationErrorHandling {
+  /// The migration will be skipped and the next migration will be executed.
+  skip,
+
+  /// The migration will be retried.
+  retry,
+
+  /// The migration will be aborted and no further migrations will be executed.
+  abort,
+}

--- a/sidekick_core/lib/src/update_sidekick_cli.dart
+++ b/sidekick_core/lib/src/update_sidekick_cli.dart
@@ -1,5 +1,6 @@
 import 'package:sidekick_core/sidekick_core.dart';
 import 'package:sidekick_core/src/commands/update_command.dart';
+import 'package:sidekick_core/src/update/migration.dart';
 import 'package:sidekick_core/src/version_checker.dart';
 
 /// Updates a sidekick CLI
@@ -12,69 +13,99 @@ import 'package:sidekick_core/src/version_checker.dart';
 Future<void> main(List<String> args) async {
   final sidekickCliName = args[0];
   final currentSidekickCliVersion = Version.parse(args[1]);
-  final latestSidekickCoreVersion = Version.parse(args[2]);
+  final targetSidekickCoreVersion = Version.parse(args[2]);
 
   print(
-    grey(
-      'Updating sidekick CLI $sidekickCliName from version $currentSidekickCliVersion to $latestSidekickCoreVersion ...',
-    ),
+    'Updating sidekick CLI $sidekickCliName from version '
+    '$currentSidekickCliVersion to $targetSidekickCoreVersion ...',
   );
 
+  /// Creating a runner to allow access to values like [repository], [mainProject] or [cliName]
   final runner = initializeSidekick(name: sidekickCliName);
   final unmount = runner.mount();
   try {
-    bool isGitDir(Directory dir) => dir.directory('.git').existsSync();
-    final entrypointDir = Repository.requiredEntryPoint.parent;
-    final repoRoot = entrypointDir.findParent(isGitDir) ?? entrypointDir;
-    final mainProjectPath = mainProject != null
-        ? relative(mainProject!.root.path, from: repoRoot.absolute.path)
-        : null;
-    final isMainProjectRoot =
-        mainProject?.root.absolute.path == repoRoot.absolute.path;
-    final hasNestedPackagesPath = mainProject != null &&
-        !relative(mainProject!.root.path, from: repoRoot.absolute.path)
-            .startsWith('packages');
-
-    final props = SidekickTemplateProperties(
-      name: Repository.requiredSidekickPackage.cliName,
-      entrypointLocation: Repository.requiredEntryPoint,
-      packageLocation: Repository.requiredCliPackage,
-      mainProjectPath: mainProjectPath,
-      shouldSetFlutterSdkPath: runner.commands.containsKey('flutter'),
-      isMainProjectRoot: isMainProjectRoot,
-      hasNestedPackagesPath: hasNestedPackagesPath,
-      sidekickCliVersion: latestSidekickCoreVersion,
+    // Throws when the migration is aborted due to an error
+    await migrate(
+      from: currentSidekickCliVersion,
+      to: targetSidekickCoreVersion,
+      migrations: [
+        // Always execute template updates
+        UpdateToolsMigration(targetSidekickCoreVersion),
+        UpdateEntryPointMigration(targetSidekickCoreVersion),
+      ],
+      onMigrationStepStart: (context) {
+        print(' - ${context.step.name}');
+      },
+      onMigrationStepError: (context) {
+        printerr('Migration failed: ${context.step.name}');
+        printerr(context.exception?.toString());
+        printerr(context.stackTrace.toString());
+        // TODO make errors interactive and allow skipping
+        return MigrationErrorHandling.abort;
+      },
     );
-
-    final template = SidekickTemplate();
-
-    // generate new shell scripts
-    template.generateTools(props);
-    template.generateEntrypoint(props);
-
-    // TODO(update-feature): run further steps necessary for update from [currentSidekickVersion] to [latestSidekickVersion]
 
     // update sidekick: cli_version: <version> in pubspec.yaml to signalize
     // that update has completed successfully
     final versionChecker = VersionChecker(Repository.requiredSidekickPackage);
     versionChecker.updateVersionConstraint(
       pubspecKeys: ['sidekick', 'cli_version'],
-      newMinimumVersion: latestSidekickCoreVersion,
+      newMinimumVersion: targetSidekickCoreVersion,
       pinVersion: true,
     );
     print(
       green(
-        'Successfully updated sidekick CLI $cliName from version $currentSidekickCliVersion to $latestSidekickCoreVersion!',
+        'Successfully updated sidekick CLI $cliName from version $currentSidekickCliVersion to $targetSidekickCoreVersion!',
       ),
     );
   } catch (_) {
     print(
       red(
-        'There was an error updating sidekick CLI $cliName from version $currentSidekickCliVersion to $latestSidekickCoreVersion.',
+        'There was an error updating sidekick CLI $cliName from version $currentSidekickCliVersion to $targetSidekickCoreVersion.',
       ),
     );
     rethrow;
   } finally {
     unmount();
+  }
+}
+
+/// Updates the /tool directory
+class UpdateToolsMigration extends MigrationStep {
+  UpdateToolsMigration(Version targetVersion)
+      : super(
+          name: 'Update /tool directory',
+          targetVersion: targetVersion,
+        );
+
+  @override
+  Future<void> migrate(MigrationContext context) async {
+    final template = SidekickTemplate();
+    final props = SidekickTemplateProperties(
+      name: Repository.requiredSidekickPackage.cliName,
+      entrypointLocation: Repository.requiredEntryPoint,
+      packageLocation: Repository.requiredCliPackage,
+    );
+    template.generateTools(props);
+  }
+}
+
+/// Updates the cli entrypoint bash script
+class UpdateEntryPointMigration extends MigrationStep {
+  UpdateEntryPointMigration(Version targetVersion)
+      : super(
+          name: 'Update entrypoint',
+          targetVersion: targetVersion,
+        );
+
+  @override
+  Future<void> migrate(MigrationContext context) async {
+    final template = SidekickTemplate();
+    final props = SidekickTemplateProperties(
+      name: Repository.requiredSidekickPackage.cliName,
+      entrypointLocation: Repository.requiredEntryPoint,
+      packageLocation: Repository.requiredCliPackage,
+    );
+    template.generateEntrypoint(props);
   }
 }

--- a/sidekick_core/test/migration_test.dart
+++ b/sidekick_core/test/migration_test.dart
@@ -1,0 +1,195 @@
+import 'package:pub_semver/pub_semver.dart';
+import 'package:sidekick_core/src/update/migration.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('executes only migrations for the current update', () async {
+    final currentVersion = Version.parse('0.4.0');
+    final updateTo = Version.parse('0.6.0');
+
+    final List<Version> executed = [];
+
+    void doMigration(MigrationContext context) {
+      executed.add(context.step.oldVersion);
+    }
+
+    final migrations = [
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.3.0'),
+        name: '0.3.0',
+      ),
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.3.5'),
+        name: '0.3.5',
+      ),
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.4.1'),
+        name: '0.4.1',
+      ),
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.5.0'),
+        name: '0.5.0',
+      ),
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.6.0'),
+        name: '0.6.0',
+      ),
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.7.0'),
+        name: '0.7.0',
+      ),
+    ];
+
+    await migrate(
+      from: currentVersion,
+      to: updateTo,
+      migrations: migrations,
+    );
+
+    expect(executed, [
+      Version.parse('0.4.1'),
+      Version.parse('0.5.0'),
+    ]);
+  });
+
+  test('Skip failing migrations executes all others', () async {
+    final currentVersion = Version.parse('0.2.0');
+    final updateTo = Version.parse('0.6.0');
+
+    final List<Version> executed = [];
+    void doMigration(MigrationContext context) {
+      executed.add(context.step.oldVersion);
+    }
+
+    final migrations = [
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.3.0'),
+        name: '0.3.0',
+      ),
+      MigrationStep(
+        (_) => throw "something went wrong",
+        oldVersion: Version.parse('0.3.5'),
+        name: '0.3.5',
+      ),
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.4.1'),
+        name: '0.4.1',
+      ),
+    ];
+
+    await migrate(
+      from: currentVersion,
+      to: updateTo,
+      migrations: migrations,
+      onMigrationError: (context) => MigrationErrorHandling.skip,
+    );
+
+    expect(executed, isNot(contains(Version.parse('0.3.5'))));
+
+    expect(executed, [
+      Version.parse('0.3.0'),
+      Version.parse('0.4.1'),
+    ]);
+  });
+
+  test('Abort failing migration stops execution of all others', () async {
+    final currentVersion = Version.parse('0.2.0');
+    final updateTo = Version.parse('0.6.0');
+
+    final List<Version> executed = [];
+    void doMigration(MigrationContext context) {
+      executed.add(context.step.oldVersion);
+    }
+
+    final migrations = [
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.3.0'),
+        name: '0.3.0',
+      ),
+      MigrationStep(
+        (_) => throw "something went wrong",
+        oldVersion: Version.parse('0.3.5'),
+        name: '0.3.5',
+      ),
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.4.1'),
+        name: '0.4.1',
+      ),
+    ];
+    try {
+      await migrate(
+        from: currentVersion,
+        to: updateTo,
+        migrations: migrations,
+        onMigrationError: (context) => MigrationErrorHandling.abort,
+      );
+      fail('should have thrown');
+    } catch (e) {
+      expect(e, "something went wrong");
+    }
+
+    expect(executed, [
+      Version.parse('0.3.0'),
+    ]);
+  });
+
+  test('Retry tries again and again and again...', () async {
+    final currentVersion = Version.parse('0.2.0');
+    final updateTo = Version.parse('0.6.0');
+
+    final List<Version> executed = [];
+    void doMigration(MigrationContext context) {
+      executed.add(context.step.oldVersion);
+    }
+
+    final migrations = [
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.3.0'),
+        name: '0.3.0',
+      ),
+      MigrationStep(
+        (_) => throw "something went wrong",
+        oldVersion: Version.parse('0.3.5'),
+        name: '0.3.5',
+      ),
+      MigrationStep(
+        doMigration,
+        oldVersion: Version.parse('0.4.1'),
+        name: '0.4.1',
+      ),
+    ];
+
+    int retryCount = 0;
+    await migrate(
+      from: currentVersion,
+      to: updateTo,
+      migrations: migrations,
+      onMigrationError: (context) {
+        retryCount++;
+        if (retryCount < 10) {
+          return MigrationErrorHandling.retry;
+        }
+        return MigrationErrorHandling.skip;
+      },
+    );
+
+    expect(retryCount, 10);
+    expect(executed, isNot(contains(Version.parse('0.3.5'))));
+
+    expect(executed, [
+      Version.parse('0.3.0'),
+      Version.parse('0.4.1'),
+    ]);
+  });
+}

--- a/sidekick_core/test/migration_test.dart
+++ b/sidekick_core/test/migration_test.dart
@@ -9,43 +9,22 @@ void main() {
 
     final List<Version> executed = [];
 
-    void doMigration(MigrationContext context) {
-      executed.add(context.step.oldVersion);
+    MigrationStep trackedMigrationTo(Version version) {
+      return MigrationStep.inline(
+        (context) => executed.add(context.step.targetVersion),
+        targetVersion: version,
+        name: version.canonicalizedVersion,
+      );
     }
 
     final migrations = [
-      MigrationStep(
-        doMigration,
-        oldVersion: Version.parse('0.3.0'),
-        name: '0.3.0',
-      ),
-      MigrationStep(
-        doMigration,
-        oldVersion: Version.parse('0.3.5'),
-        name: '0.3.5',
-      ),
-      MigrationStep(
-        doMigration,
-        oldVersion: Version.parse('0.4.1'),
-        name: '0.4.1',
-      ),
-      MigrationStep(
-        doMigration,
-        oldVersion: Version.parse('0.5.0'),
-        name: '0.5.0',
-      ),
-      MigrationStep(
-        doMigration,
-        oldVersion: Version.parse('0.6.0'),
-        name: '0.6.0',
-      ),
-      MigrationStep(
-        doMigration,
-        oldVersion: Version.parse('0.7.0'),
-        name: '0.7.0',
-      ),
+      trackedMigrationTo(Version(0, 3, 0)),
+      trackedMigrationTo(Version(0, 3, 5)),
+      trackedMigrationTo(Version(0, 4, 1)),
+      trackedMigrationTo(Version(0, 5, 0)),
+      trackedMigrationTo(Version(0, 6, 0)),
+      trackedMigrationTo(Version(0, 7, 0)),
     ];
-
     await migrate(
       from: currentVersion,
       to: updateTo,
@@ -53,8 +32,9 @@ void main() {
     );
 
     expect(executed, [
-      Version.parse('0.4.1'),
-      Version.parse('0.5.0'),
+      Version(0, 4, 1),
+      Version(0, 5, 0),
+      Version(0, 6, 0),
     ]);
   });
 
@@ -64,23 +44,23 @@ void main() {
 
     final List<Version> executed = [];
     void doMigration(MigrationContext context) {
-      executed.add(context.step.oldVersion);
+      executed.add(context.step.targetVersion);
     }
 
     final migrations = [
-      MigrationStep(
+      MigrationStep.inline(
         doMigration,
-        oldVersion: Version.parse('0.3.0'),
+        targetVersion: Version.parse('0.3.0'),
         name: '0.3.0',
       ),
-      MigrationStep(
+      MigrationStep.inline(
         (_) => throw "something went wrong",
-        oldVersion: Version.parse('0.3.5'),
+        targetVersion: Version.parse('0.3.5'),
         name: '0.3.5',
       ),
-      MigrationStep(
+      MigrationStep.inline(
         doMigration,
-        oldVersion: Version.parse('0.4.1'),
+        targetVersion: Version.parse('0.4.1'),
         name: '0.4.1',
       ),
     ];
@@ -89,7 +69,7 @@ void main() {
       from: currentVersion,
       to: updateTo,
       migrations: migrations,
-      onMigrationError: (context) => MigrationErrorHandling.skip,
+      onMigrationStepError: (context) => MigrationErrorHandling.skip,
     );
 
     expect(executed, isNot(contains(Version.parse('0.3.5'))));
@@ -106,23 +86,23 @@ void main() {
 
     final List<Version> executed = [];
     void doMigration(MigrationContext context) {
-      executed.add(context.step.oldVersion);
+      executed.add(context.step.targetVersion);
     }
 
     final migrations = [
-      MigrationStep(
+      MigrationStep.inline(
         doMigration,
-        oldVersion: Version.parse('0.3.0'),
+        targetVersion: Version.parse('0.3.0'),
         name: '0.3.0',
       ),
-      MigrationStep(
+      MigrationStep.inline(
         (_) => throw "something went wrong",
-        oldVersion: Version.parse('0.3.5'),
+        targetVersion: Version.parse('0.3.5'),
         name: '0.3.5',
       ),
-      MigrationStep(
+      MigrationStep.inline(
         doMigration,
-        oldVersion: Version.parse('0.4.1'),
+        targetVersion: Version.parse('0.4.1'),
         name: '0.4.1',
       ),
     ];
@@ -131,7 +111,7 @@ void main() {
         from: currentVersion,
         to: updateTo,
         migrations: migrations,
-        onMigrationError: (context) => MigrationErrorHandling.abort,
+        onMigrationStepError: (context) => MigrationErrorHandling.abort,
       );
       fail('should have thrown');
     } catch (e) {
@@ -149,23 +129,23 @@ void main() {
 
     final List<Version> executed = [];
     void doMigration(MigrationContext context) {
-      executed.add(context.step.oldVersion);
+      executed.add(context.step.targetVersion);
     }
 
     final migrations = [
-      MigrationStep(
+      MigrationStep.inline(
         doMigration,
-        oldVersion: Version.parse('0.3.0'),
+        targetVersion: Version.parse('0.3.0'),
         name: '0.3.0',
       ),
-      MigrationStep(
+      MigrationStep.inline(
         (_) => throw "something went wrong",
-        oldVersion: Version.parse('0.3.5'),
+        targetVersion: Version.parse('0.3.5'),
         name: '0.3.5',
       ),
-      MigrationStep(
+      MigrationStep.inline(
         doMigration,
-        oldVersion: Version.parse('0.4.1'),
+        targetVersion: Version.parse('0.4.1'),
         name: '0.4.1',
       ),
     ];
@@ -175,7 +155,7 @@ void main() {
       from: currentVersion,
       to: updateTo,
       migrations: migrations,
-      onMigrationError: (context) {
+      onMigrationStepError: (context) {
         retryCount++;
         if (retryCount < 10) {
           return MigrationErrorHandling.retry;

--- a/sidekick_core/test/update_command_test.dart
+++ b/sidekick_core/test/update_command_test.dart
@@ -63,9 +63,7 @@ void main() {
         expect(
           printLog,
           containsAllInOrder([
-            grey(
-              'Updating sidekick CLI dash from version 0.0.0 to $targetVersion ...',
-            ),
+            'Updating sidekick CLI dash from version 0.0.0 to $targetVersion ...',
             green(
               'Successfully updated sidekick CLI dash from version 0.0.0 to $targetVersion!',
             ),


### PR DESCRIPTION
To prepare for more migrations (as required by #157) I prepared a tiny migration framework
- Detects which migrations steps to execute
- Allows skipping of failed steps

I converted the current migrations (update tools and update entrypoint) into separate steps which get always executed.

It should now be easy to add new migrations