### PR TITLE
Run `pub upgrade` when compilation fails

### DIFF
--- a/sidekick_core/lib/src/template/install.sh.template.dart
+++ b/sidekick_core/lib/src/template/install.sh.template.dart
@@ -59,9 +59,23 @@ cd "${CLI_PACKAGE_DIR}" || exit
   echoerr "✔ Bundling assets"
 
   echoerr "- Compiling sidekick cli"
-  runSilent "${DART}" compile exe -o "${EXE}" bin/main.dart
-  deleteLine
-  echoerr "✔ Compiling sidekick cli"
+  if runSilent "${DART}" compile exe -o "${EXE}" bin/main.dart; then
+    deleteLine
+    echoerr "✔ Compiling sidekick cli"
+  else
+    echoerr "Compilation failed. Trying dart pub upgrade"
+    LOCK_FILE=$(cat pubspec.lock)
+    runSilent "${DART}" pub upgrade
+    echoerr "- Compiling sidekick cli with updated dependencies"
+    if runSilent "${DART}" compile exe -o "${EXE}" bin/main.dart; then
+      deleteLine
+      echoerr "✔ Compiling sidekick cli with updated dependencies"
+    else
+      echoerr "Compilation with updated dependencies failed, too. Restoring pubspec.lock"
+      echo "$LOCK_FILE" > pubspec.lock
+      exit 1
+    fi
+  fi
   echoerr "🎉Success!\n"
 
 cd "${CWD}" || exit

--- a/sidekick_core/lib/src/template/install.sh.template.dart
+++ b/sidekick_core/lib/src/template/install.sh.template.dart
@@ -25,10 +25,10 @@ runSilent() {
   output=$("$@" 2>&1)
   local EXIT_CODE=$?;
   if [ $EXIT_CODE -ne 0 ]; then
-    printerr "$output"
-    exit $EXIT_CODE
+    echoerr "$output"
   fi
   set -e
+  return $EXIT_CODE
 }
 
 cd "${CLI_PACKAGE_DIR}" || exit


### PR DESCRIPTION
When upgrading the dart sdk, or adding new dependencies, the CLI may not be able to compile again. Now, the `install.sh` script runs `pub upgrade` in case of a compilation error and then recompiles.
If the recovery strategy fails, the script restores the previous `pubspec.lock`