### PR TITLE
Add BashCommand

### DIFF
--- a/sidekick_core/lib/sidekick_core.dart
+++ b/sidekick_core/lib/sidekick_core.dart
@@ -20,6 +20,7 @@ export 'package:dcli/dcli.dart' hide run, start, startFromArgs, absolute;
 export 'package:pub_semver/pub_semver.dart' show Version;
 export 'package:sidekick_core/src/cli_util.dart';
 export 'package:sidekick_core/src/commands/analyze_command.dart';
+export 'package:sidekick_core/src/commands/bash_command.dart';
 export 'package:sidekick_core/src/commands/dart_command.dart';
 export 'package:sidekick_core/src/commands/deps_command.dart';
 export 'package:sidekick_core/src/commands/flutter_command.dart';

--- a/sidekick_core/lib/src/cli_util.dart
+++ b/sidekick_core/lib/src/cli_util.dart
@@ -36,21 +36,33 @@ io.File tempExecutableScriptFile(String content, {Directory? tempDir}) {
 }
 
 /// Executes a script by first writing it as file and then running it as shell script
+///
+/// Use [args] to pass arguments to the script
+///
+/// Use [workingDirectory] to set the working directory of the script, default
+/// to current working directory
+///
+/// When [terminal] is `true` (default: `false`) Stdio handles are inherited by
+/// the child process. This allows stdin to read by the script
 dcli.Progress writeAndRunShellScript(
   String scriptContent, {
+  List<String> args = const [],
   Directory? workingDirectory,
   dcli.Progress? progress,
+  bool terminal = false,
 }) {
   final script = tempExecutableScriptFile(scriptContent);
   final Progress scriptProgress =
       progress ?? Progress(print, stderr: printerr, captureStderr: true);
 
   try {
-    return dcli.start(
+    return dcli.startFromArgs(
       script.absolute.path,
+      args,
       workingDirectory:
           workingDirectory?.absolute.path ?? entryWorkingDirectory.path,
       progress: scriptProgress,
+      terminal: terminal,
     );
   } catch (e) {
     print(

--- a/sidekick_core/lib/src/commands/bash_command.dart
+++ b/sidekick_core/lib/src/commands/bash_command.dart
@@ -122,7 +122,7 @@ class BashCommandException implements Exception {
   final StackTrace stack;
 
   /// The original exception from dcli
-  final Object? cause;
+  final Object cause;
 
   const BashCommandException({
     required this.script,

--- a/sidekick_core/lib/src/commands/bash_command.dart
+++ b/sidekick_core/lib/src/commands/bash_command.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:sidekick_core/sidekick_core.dart';
 import 'package:dcli/dcli.dart' as dcli;
+import 'package:sidekick_core/sidekick_core.dart';
 
 /// A Command that wraps a bash script
 ///
@@ -135,8 +135,10 @@ class BashCommandException implements Exception {
 
   @override
   String toString() {
-    String args = arguments.joinToString();
-    if (args.isBlank) {
+    String args = arguments.joinToString(separator: ' ');
+    if (!args.isBlank) {
+      args = "($args)";
+    } else {
       args = '<no arguments>';
     }
     return "Error (exitCode=$exitCode) executing script of command '$commandName' "

--- a/sidekick_core/lib/src/commands/bash_command.dart
+++ b/sidekick_core/lib/src/commands/bash_command.dart
@@ -9,21 +9,37 @@ import 'package:sidekick_core/sidekick_core.dart';
 /// This makes it easy to handle paths within the bash script. You can define a
 /// static [workingDirectory] and always know where the script is executed.
 ///
-/// Usage:
+/// Usage as plain text
 /// ```dart
 /// runner
-///    ..addCommand(
-///       BashCommand(
-///         name: 'test-bash-command',
-///         description: 'Prints inputs of a sidekick BashCommand',
-///         workingDirectory: runner.repository.root,
-///         script: () => '''
+///   ..addCommand(
+///      BashCommand(
+///        name: 'test-bash-command',
+///        description: 'Prints inputs of a sidekick BashCommand',
+///        workingDirectory: runner.repository.root,
+///        script: () => '''
 /// echo "arguments: \$@"
 /// echo "workingDirectory: \$(pwd)"
 /// # Access paths from sidekick
 /// ${systemFlutterSdkPath()}/bin/flutter --version
-///       ''',
-///       );
+/// ''',
+///     ),
+///   );
+/// ```
+///
+/// Or load your script from a file
+/// ```dart
+/// runner
+///   ..addCommand(
+///     BashCommand(
+///       name: 'test-bash-command',
+///       description: 'Prints inputs of a sidekick BashCommand',
+///       workingDirectory: runner.repository.root,
+///       script: () => runner.repository.root
+///           .file('scripts/test-bash-command.sh')
+///           .readAsString(),
+///     ),
+///   )
 /// ```
 class BashCommand extends ForwardCommand {
   BashCommand({

--- a/sidekick_core/lib/src/commands/bash_command.dart
+++ b/sidekick_core/lib/src/commands/bash_command.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:sidekick_core/sidekick_core.dart';
+
+/// A Command that wraps a bash script
+///
+/// Easy way to convert an existing bash script into a command for sidekick
+///
+/// This makes it easy to handle paths within the bash script. You can define a
+/// static [workingDirectory] and always know where the script is executed.
+///
+/// Usage:
+/// ```dart
+/// runner
+///    ..addCommand(
+///       BashCommand(
+///         name: 'test-bash-command',
+///         description: 'Prints inputs of a sidekick BashCommand',
+///         workingDirectory: runner.repository.root,
+///         script: () => '''
+/// echo "arguments: \$@"
+/// echo "workingDirectory: \$(pwd)"
+/// # Access paths from sidekick
+/// ${systemFlutterSdkPath()}/bin/flutter --version
+///       ''',
+///       );
+/// ```
+class BashCommand extends ForwardCommand {
+  BashCommand({
+    required this.script,
+    required this.description,
+    required this.name,
+    this.workingDirectory,
+  });
+
+  @override
+  final String name;
+
+  @override
+  final String description;
+
+  /// The script to be executed.
+  ///
+  /// You may load this script from a file or generate it on the fly.
+  final FutureOr<String> Function() script;
+
+  /// The directory the bash script is running in.
+  final Directory? workingDirectory;
+
+  @override
+  Future<void> run() async {
+    final bashScript = await script();
+    writeAndRunShellScript(
+      bashScript,
+      args: argResults!.arguments,
+      workingDirectory: workingDirectory,
+      terminal: true,
+    );
+  }
+}

--- a/sidekick_core/lib/src/commands/bash_command.dart
+++ b/sidekick_core/lib/src/commands/bash_command.dart
@@ -41,13 +41,16 @@ import 'package:sidekick_core/sidekick_core.dart';
 ///     ),
 ///   )
 /// ```
+///
+/// If your script is interactive, set [withStdIn] to `true` to allow stdin to
+/// be connected to the script.
 class BashCommand extends ForwardCommand {
   BashCommand({
     required this.script,
     required this.description,
     required this.name,
     this.workingDirectory,
-    this.withStdIn = true,
+    this.withStdIn = false,
   });
 
   @override

--- a/sidekick_core/lib/src/commands/bash_command.dart
+++ b/sidekick_core/lib/src/commands/bash_command.dart
@@ -47,6 +47,7 @@ class BashCommand extends ForwardCommand {
     required this.description,
     required this.name,
     this.workingDirectory,
+    this.withStdIn = true,
   });
 
   @override
@@ -63,6 +64,9 @@ class BashCommand extends ForwardCommand {
   /// The directory the bash script is running in.
   final Directory? workingDirectory;
 
+  /// Whether to forward stdin to the bash script, default to true
+  final bool withStdIn;
+
   @override
   Future<void> run() async {
     final bashScript = await script();
@@ -70,7 +74,7 @@ class BashCommand extends ForwardCommand {
       bashScript,
       args: argResults!.arguments,
       workingDirectory: workingDirectory,
-      terminal: true,
+      terminal: withStdIn,
     );
   }
 }

--- a/sidekick_core/lib/src/forward_command.dart
+++ b/sidekick_core/lib/src/forward_command.dart
@@ -3,7 +3,7 @@ import 'package:args/command_runner.dart';
 
 /// A [Command] which accepts all arguments and forwards everything to another cli app
 ///
-/// Arguments to format are available via `argResults!.arguments`
+/// Arguments are available via `argResults!.arguments`, not `argResults!.rest`
 abstract class ForwardCommand extends Command {
   ForwardCommand() {
     // recreate the _argParser and change it to allowAnything

--- a/sidekick_core/test/bash_command_test.dart
+++ b/sidekick_core/test/bash_command_test.dart
@@ -100,18 +100,17 @@ void main() {
       } catch (e) {
         expect(
           e,
-          isA<RunException>().having((it) => it.exitCode, 'exitCode', 34),
+          isA<BashCommandException>()
+              .having((it) => it.exitCode, 'exitCode', 34)
+              .having((it) => it.script, 'script', contains('#scriptContent'))
+              .having(
+                  (it) => it.toString(), 'toString()', contains('exitCode=34'))
+              .having((it) => it.toString(), 'toString()',
+                  contains('<no arguments>')),
         );
       }
-
-      expect(fakeStdErr.lines.join(), contains('exitCode=34'));
-      expect(fakeStdErr.lines.join(), contains('#scriptContent'));
-      expect(fakeStdErr.lines.join(), contains('exit 34'));
-      expect(
-        fakeStdErr.lines.join(),
-        contains("Error executing script 'script'"),
-      );
       expect(fakeStdOut.lines.join(), "");
+      expect(fakeStdErr.lines.join(), "");
     });
   });
 }

--- a/sidekick_core/test/bash_command_test.dart
+++ b/sidekick_core/test/bash_command_test.dart
@@ -1,0 +1,80 @@
+import 'package:sidekick_core/sidekick_core.dart';
+import 'package:sidekick_test/fake_stdio.dart';
+import 'package:sidekick_test/sidekick_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('bash command receives arguments', () async {
+    await insideFakeProjectWithSidekick((dir) async {
+      final runner = initializeSidekick(
+        name: 'dash',
+        dartSdkPath: fakeDartSdk().path,
+      );
+      runner.addCommand(
+        BashCommand(
+          script: () => 'echo \$@',
+          description: 'description',
+          name: 'script',
+          withStdIn: false,
+        ),
+      );
+      final fakeStdOut = FakeStdoutStream();
+      await overrideIoStreams(
+        stdout: () => fakeStdOut,
+        body: () => runner.run(['script', 'asdf', 'qwer']),
+      );
+
+      expect(fakeStdOut.lines, contains('asdf qwer'));
+    });
+  });
+
+  test('workingDirectory default to cwd', () async {
+    await insideFakeProjectWithSidekick((dir) async {
+      final runner = initializeSidekick(
+        name: 'dash',
+        dartSdkPath: fakeDartSdk().path,
+      );
+      runner.addCommand(
+        BashCommand(
+          script: () => 'echo \$PWD',
+          description: 'description',
+          name: 'script',
+          withStdIn: false,
+        ),
+      );
+      final fakeStdOut = FakeStdoutStream();
+      await overrideIoStreams(
+        stdout: () => fakeStdOut,
+        body: () => runner.run(['script']),
+      );
+
+      expect(fakeStdOut.lines.join(), endsWith(Directory.current.path));
+    });
+  });
+
+  test('workingDirectory can be set', () async {
+    await insideFakeProjectWithSidekick((dir) async {
+      final subDir = dir.directory('someSubDir')..createSync();
+      final runner = initializeSidekick(
+        name: 'dash',
+        dartSdkPath: fakeDartSdk().path,
+      );
+      runner.addCommand(
+        BashCommand(
+          script: () => 'echo \$PWD',
+          description: 'description',
+          name: 'script',
+          withStdIn: false,
+          workingDirectory: subDir,
+        ),
+      );
+      final fakeStdOut = FakeStdoutStream();
+      await overrideIoStreams(
+        stdout: () => fakeStdOut,
+        body: () => runner.run(['script']),
+      );
+
+      expect(fakeStdOut.lines.join(), endsWith(subDir.path));
+    });
+  });
+}

--- a/sidekick_core/test/bash_command_test.dart
+++ b/sidekick_core/test/bash_command_test.dart
@@ -88,14 +88,8 @@ void main() {
           name: 'script',
         ),
       );
-      final fakeStdOut = FakeStdoutStream();
-      final fakeStdErr = FakeStdoutStream();
       try {
-        await overrideIoStreams(
-          stdout: () => fakeStdOut,
-          stderr: () => fakeStdErr,
-          body: () => runner.run(['script']),
-        );
+        await runner.run(['script']);
         fail('should throw');
       } catch (e) {
         expect(
@@ -103,6 +97,17 @@ void main() {
           isA<BashCommandException>()
               .having((it) => it.exitCode, 'exitCode', 34)
               .having((it) => it.script, 'script', contains('#scriptContent'))
+              .having((it) => it.commandName, 'commandName', 'script')
+              .having((it) => it.arguments, 'arguments', [])
+              .having((it) => it.cause, 'cause', isA<RunException>())
+              .having(
+                  (it) => it.stack,
+                  'stack',
+                  isA<StackTrace>().having(
+                    (it) => it.toString(),
+                    'toString',
+                    contains('bash_command_test.dart'),
+                  ))
               .having(
                 (it) => it.toString(),
                 'toString()',
@@ -115,8 +120,6 @@ void main() {
               ),
         );
       }
-      expect(fakeStdOut.lines.join(), "");
-      expect(fakeStdErr.lines.join(), "");
     });
   });
 
@@ -133,35 +136,22 @@ void main() {
           name: 'script',
         ),
       );
-      final fakeStdOut = FakeStdoutStream();
-      final fakeStdErr = FakeStdoutStream();
       try {
-        await overrideIoStreams(
-          stdout: () => fakeStdOut,
-          stderr: () => fakeStdErr,
-          body: () => runner.run(['script', 'asdf', 'qwer']),
-        );
+        await runner.run(['script', 'asdf', 'qwer']);
         fail('should throw');
       } catch (e) {
         expect(
           e,
           isA<BashCommandException>()
               .having((it) => it.exitCode, 'exitCode', 34)
-              .having((it) => it.script, 'script', contains('#scriptContent'))
               .having(
-                (it) => it.toString(),
-                'toString()',
-                contains('exitCode=34'),
-              )
-              .having(
-                (it) => it.toString(),
-                'toString()',
-                contains('asdf qwer'),
-              ),
+                  (it) => it.arguments, 'arguments', ['asdf', 'qwer']).having(
+            (it) => it.toString(),
+            'toString()',
+            contains('asdf qwer'),
+          ),
         );
       }
-      expect(fakeStdOut.lines.join(), "");
-      expect(fakeStdErr.lines.join(), "");
     });
   });
 }


### PR DESCRIPTION
A new command that allows writing a sidekick command as bash script

Usage:
```dart
runner
   ..addCommand(
      BashCommand(
        name: 'test-bash-command',
        description: 'Prints inputs of a sidekick BashCommand',
        workingDirectory: runner.repository.root,
        script: () => '''
echo "arguments: \$@"
echo "workingDirectory: \$(pwd)"
# Access paths from sidekick
${systemFlutterSdkPath()}/bin/flutter --version
      ''',
      ),
    );
```

Prints

```
❯ sk test-bash-command asdf -s qwer
arguments: asdf -s qwer
working directory: /Users/pascalwelsch/Projects/phntmxyz/sidekick
Flutter 3.3.10 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 135454af32 (3 weeks ago) • 2022-12-15 07:36:55 -0800
Engine • revision 3316dd8728
Tools • Dart 2.18.6 • DevTools 2.15.0
```