### PR TITLE
Refactor updateVersionConstraint using YamlEditor

### DIFF
--- a/sidekick_core/test/version_checker_test.dart
+++ b/sidekick_core/test/version_checker_test.dart
@@ -93,6 +93,31 @@ dependencies:
 ''',
       );
     });
+
+    test('replace path dependency with pub version', () async {
+      pubspecYamlFile.writeAsStringSync('''
+name: dashi
+dependencies:
+  sidekick_core:
+    path: ../sidekick_core
+''');
+
+      VersionChecker.updateVersionConstraint(
+        package: package,
+        pubspecKeys: ['dependencies', 'sidekick_core'],
+        newMinimumVersion: Version(0, 14, 0),
+        pinVersion: true,
+      );
+
+      expect(
+        pubspecYamlFile.readAsStringSync(),
+        '''
+name: dashi
+dependencies:
+  sidekick_core: 0.14.0
+''',
+      );
+    });
   });
 
   group('VersionChecker.getMinimumVersionConstraint', () {

--- a/sidekick_core/test/version_checker_test.dart
+++ b/sidekick_core/test/version_checker_test.dart
@@ -119,7 +119,7 @@ dependencies:
       );
     });
 
-    test('replace path dependency with pub version', () async {
+    test('replace git dependency with pub version', () async {
       pubspecYamlFile.writeAsStringSync('''
 name: dashi
 dependencies:

--- a/sidekick_core/test/version_checker_test.dart
+++ b/sidekick_core/test/version_checker_test.dart
@@ -118,6 +118,33 @@ dependencies:
 ''',
       );
     });
+
+    test('replace path dependency with pub version', () async {
+      pubspecYamlFile.writeAsStringSync('''
+name: dashi
+dependencies:
+  some_sidekick_plugin:
+    git:
+      url: git@github.com:phntmxyz/some_sidekick_plugin.git
+      ref: main
+''');
+
+      VersionChecker.updateVersionConstraint(
+        package: package,
+        pubspecKeys: ['dependencies', 'some_sidekick_plugin'],
+        newMinimumVersion: Version(0, 14, 0),
+        pinVersion: true,
+      );
+
+      expect(
+        pubspecYamlFile.readAsStringSync(),
+        '''
+name: dashi
+dependencies:
+  some_sidekick_plugin: 0.14.0
+''',
+      );
+    });
   });
 
   group('VersionChecker.getMinimumVersionConstraint', () {

--- a/sidekick_core/test/version_checker_test.dart
+++ b/sidekick_core/test/version_checker_test.dart
@@ -65,9 +65,9 @@ dependencies:
         pubspecYamlFile.readAsStringSync(),
         '''
 name: dashi
-dependencies:
-  foo: 1.2.4
+dependencies: 
   bar: 0.0.0
+  foo: 1.2.4
 ''',
       );
     });
@@ -87,9 +87,9 @@ name: dashi
         pubspecYamlFile.readAsStringSync(),
         '''
 name: dashi
-# the pubspec does not have a dependencies block, it should be added by updateVersionConstraint
 dependencies:
   foo: 1.2.4
+# the pubspec does not have a dependencies block, it should be added by updateVersionConstraint
 ''',
       );
     });


### PR DESCRIPTION
Replaces our existing regex solution with `YamlEditor`. This solves updating a dependency to a pub version that uses a path reference.

```yaml
dependencies:
  sidekick_core:
    path: ../sidekick_core
```
Now correctly converts to.

```yaml
dependencies:
  sidekick_core: ^0.14.0
```

Was converting to this syntax error before:
```yaml
dependencies:
  sidekick_core:  ^0.14.0
    path: ../sidekick_core
```