### PR TITLE
Simplify flutter package detection

### DIFF
--- a/sidekick_core/lib/src/dart_package.dart
+++ b/sidekick_core/lib/src/dart_package.dart
@@ -28,8 +28,8 @@ class DartPackage {
 
       // Check for (optional) flutter dependency
       final deps = pubspec['dependencies'] as YamlMap?;
-      final flutterDep = deps?['flutter'] as YamlMap?;
-      if (flutterDep != null) {
+      final withFlutter = deps?.containsKey('flutter') == true;
+      if (withFlutter) {
         return DartPackage.flutter(normalizedDir, packageName);
       }
       return DartPackage(normalizedDir, packageName);

--- a/sidekick_core/lib/src/dart_package.dart
+++ b/sidekick_core/lib/src/dart_package.dart
@@ -28,7 +28,7 @@ class DartPackage {
 
       // Check for (optional) flutter dependency
       final deps = pubspec['dependencies'] as YamlMap?;
-      final withFlutter = deps?.containsKey('flutter') == true;
+      final withFlutter = deps?.containsKey('flutter') ?? false;
       if (withFlutter) {
         return DartPackage.flutter(normalizedDir, packageName);
       }

--- a/sidekick_core/test/dart_package.dart
+++ b/sidekick_core/test/dart_package.dart
@@ -30,4 +30,62 @@ void main() {
       expect(isValidPubPackageName('no-dash'), isFalse);
     });
   });
+
+  group('DartPackage.fromDirectory', () {
+    test('detect dart package', () {
+      final tempDir = Directory.systemTemp.createTempSync();
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+      tempDir.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync('''
+name: package_name
+
+''');
+
+      final package = DartPackage.fromDirectory(tempDir);
+      expect(package, isNotNull);
+      expect(package!.name, 'package_name');
+      expect(package.isFlutterPackage, isFalse);
+    });
+
+    test('detect minimal flutter package', () {
+      final tempDir = Directory.systemTemp.createTempSync();
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+      tempDir.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync('''
+name: package_name
+
+dependencies:
+  flutter:
+''');
+
+      final package = DartPackage.fromDirectory(tempDir);
+      expect(package, isNotNull);
+      expect(package!.name, 'package_name');
+      expect(package.isFlutterPackage, isTrue);
+    });
+
+    test('detect usually looking flutter package', () {
+      final tempDir = Directory.systemTemp.createTempSync();
+      addTearDown(() => tempDir.deleteSync(recursive: true));
+      tempDir.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync('''
+name: package_name
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true
+''');
+
+      final package = DartPackage.fromDirectory(tempDir);
+      expect(package, isNotNull);
+      expect(package!.name, 'package_name');
+      expect(package.isFlutterPackage, isTrue);
+    });
+  });
 }


### PR DESCRIPTION
dependency `flutter` may not be a `YamlMap`, all we care about is the existence of the dependency