### PR TITLE
Exclude via glob, starting search at repo root

### DIFF
--- a/sidekick_core/lib/src/commands/deps_command.dart
+++ b/sidekick_core/lib/src/commands/deps_command.dart
@@ -14,6 +14,27 @@ class DepsCommand extends Command {
   final List<DartPackage> exclude;
 
   /// glob patterns of packages whose dependencies should not be loaded
+  ///
+  /// Search starts at repository root.
+  ///
+  /// Example project layout:
+  ///
+  /// ```
+  /// repo-root
+  /// ├── packages
+  /// │   ├── package1
+  /// │   ├── package2
+  /// │   └── circle
+  /// └── third_party
+  ///     ├── circle
+  ///     │   ├── packageA
+  ///     │   └── packageB
+  ///     └── square
+  /// ```
+  ///
+  /// - Use `packages/package1/**` to exclude only `packages/package1`.
+  /// - Use `**/circle/**` to exclude `packages/circle` as well as
+  ///   `third_party/circle/packageA` and `third_party/circle/packageB`.
   final List<String> excludeGlob;
 
   DepsCommand({

--- a/sidekick_core/lib/src/commands/deps_command.dart
+++ b/sidekick_core/lib/src/commands/deps_command.dart
@@ -47,14 +47,11 @@ class DepsCommand extends Command {
     final errorBuffer = StringBuffer();
 
     final excluded = excludeGlob
-        .map((p) => Glob(p))
-        .map(
-          (e) => e.listSync(
-            // See https://github.com/dart-lang/glob/issues/52
-            root: Directory.current.path,
-          ),
-        )
-        .expand((e) => e) // flattens nested list
+        .expand((rule) {
+          // start search at repo root
+          final root = repository.root.path;
+          return Glob("$root/$rule").listSync(root: root);
+        })
         .whereType<Directory>()
         .mapNotNull((e) => DartPackage.fromDirectory(e))
         .append(exclude);

--- a/sidekick_core/test/deps_command_test.dart
+++ b/sidekick_core/test/deps_command_test.dart
@@ -56,7 +56,7 @@ environment:
     });
   });
 
-  test('deps respects exclude parameters ', () async {
+  test('deps respects exclude parameters', () async {
     await insideFakeProjectWithSidekick((dir) async {
       final fakeStdOut = FakeStdoutStream();
       await overrideIoStreams(
@@ -89,6 +89,102 @@ environment:
             'foo_a',
             'foo_b',
             'foo_bar_baz',
+          ].map((e) => yellow('=== package $e ==='));
+          for (final excluded in excludedPackages) {
+            expect(fakeStdOut.lines, isNot(anyElement(excluded)));
+          }
+        },
+      );
+    });
+  });
+
+  test('glob searches from repo root, not cwd', () async {
+    await insideFakeProjectWithSidekick((dir) async {
+      final fakeStdOut = FakeStdoutStream();
+      await overrideIoStreams(
+        stdout: () => fakeStdOut,
+        body: () async {
+          setUpPackages(dir);
+
+          // move to a different dir
+          final otherDir = Directory.systemTemp.createTempSync('');
+          addTearDown(() => otherDir.deleteSync());
+          IOOverrides.current!.setCurrentDirectory(otherDir.path);
+
+          final runner = initializeSidekick(
+            name: 'dash',
+            dartSdkPath: systemDartSdkPath(),
+          );
+
+          // exclude `<repo-root>/foo/bar/baz`
+          runner.addCommand(
+            DepsCommand(
+              excludeGlob: ['**/bar/**'],
+            ),
+          );
+          await runner.run(['deps']);
+          expect(exitCode, 0);
+
+          final includedPackages = [
+            'main_project',
+            'test_a',
+            'test_b',
+            'dash',
+            'foo_a',
+            'foo_b',
+          ].map((e) => yellow('=== package $e ==='));
+          expect(fakeStdOut.lines, containsAll(includedPackages));
+
+          final excludedPackages = [
+            'foo_bar_baz',
+          ].map((e) => yellow('=== package $e ==='));
+          for (final excluded in excludedPackages) {
+            expect(fakeStdOut.lines, isNot(anyElement(excluded)));
+          }
+        },
+      );
+    });
+  });
+
+  test('glob filter all packages in <repo-root>/foo/', () async {
+    await insideFakeProjectWithSidekick((dir) async {
+      final fakeStdOut = FakeStdoutStream();
+      await overrideIoStreams(
+        stdout: () => fakeStdOut,
+        body: () async {
+          setUpPackages(dir);
+
+          // move to a different dir
+          final otherDir = Directory.systemTemp.createTempSync('');
+          addTearDown(() => otherDir.deleteSync());
+          IOOverrides.current!.setCurrentDirectory(otherDir.path);
+
+          final runner = initializeSidekick(
+            name: 'dash',
+            dartSdkPath: systemDartSdkPath(),
+          );
+
+          // exclude all packages in `<repo-root>/foo/`
+          runner.addCommand(
+            DepsCommand(
+              excludeGlob: ['foo/**'],
+            ),
+          );
+          await runner.run(['deps']);
+          expect(exitCode, 0);
+
+          final includedPackages = [
+            'main_project',
+            'test_a',
+            'test_b',
+            'dash',
+          ].map((e) => yellow('=== package $e ==='));
+          expect(fakeStdOut.lines, containsAll(includedPackages));
+
+          final excludedPackages = [
+            'foo_bar_baz',
+            'foo_a',
+            'foo_b',
           ].map((e) => yellow('=== package $e ==='));
           for (final excluded in excludedPackages) {
             expect(fakeStdOut.lines, isNot(anyElement(excluded)));

--- a/sidekick_test/lib/src/local_testing.dart
+++ b/sidekick_test/lib/src/local_testing.dart
@@ -108,9 +108,11 @@ sidekick:
     env['SIDEKICK_ENTRYPOINT_HOME'] = null;
   });
 
+  Directory cwd = tempDir;
   return IOOverrides.runZoned<R>(
     () => callback(tempDir),
-    getCurrentDirectory: () => tempDir,
+    getCurrentDirectory: () => cwd,
+    setCurrentDirectory: (dir) => cwd = Directory(dir),
   );
 }
 


### PR DESCRIPTION
I discovered that the exclusions depended on `cwd`. I fixed the search to repo root