### PR TITLE
sk coverage

### DIFF
--- a/sidekick/.gitignore
+++ b/sidekick/.gitignore
@@ -4,6 +4,7 @@
 .dart_tool/
 .packages
 build/
+coverage/
 
 # Directory created by dartdoc
 # If you don't generate documentation locally you can remove this line.

--- a/sidekick_core/.gitignore
+++ b/sidekick_core/.gitignore
@@ -4,6 +4,8 @@
 .dart_tool/
 .packages
 build/
+coverage/
+
 # If you're building an application, you may want to check-in your pubspec.lock
 pubspec.lock
 

--- a/sidekick_plugin_installer/.gitignore
+++ b/sidekick_plugin_installer/.gitignore
@@ -4,6 +4,8 @@
 .dart_tool/
 .packages
 build/
+coverage/
+
 # If you're building an application, you may want to check-in your pubspec.lock
 pubspec.lock
 

--- a/sidekick_vault/.gitignore
+++ b/sidekick_vault/.gitignore
@@ -4,6 +4,8 @@
 .dart_tool/
 .packages
 build/
+coverage/
+
 # If you're building an application, you may want to check-in your pubspec.lock
 pubspec.lock
 

--- a/sk_sidekick/.gitignore
+++ b/sk_sidekick/.gitignore
@@ -1,6 +1,7 @@
 # Files and directories created by pub
 .dart_tool/
 .packages
+coverage/
 
 # Conventional directory for build outputs
 build/

--- a/sk_sidekick/lib/sk_sidekick.dart
+++ b/sk_sidekick/lib/sk_sidekick.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:sidekick_core/sidekick_core.dart';
 import 'package:sk_sidekick/src/commands/bump_version_command.dart';
+import 'package:sk_sidekick/src/commands/coverage_command.dart';
 import 'package:sk_sidekick/src/commands/lock_dependencies_command.dart';
 import 'package:sk_sidekick/src/commands/release_command.dart';
 import 'package:sk_sidekick/src/commands/verify_publish_state_command.dart';
@@ -19,6 +20,7 @@ Future<void> runSk(List<String> args) async {
 
   skProject = SkProject(runner.repository.root);
   runner
+    ..addCommand(CoverageCommand())
     ..addCommand(DartCommand())
     ..addCommand(DepsCommand(excludeGlob: ['**/templates/**']))
     ..addCommand(DartAnalyzeCommand())

--- a/sk_sidekick/lib/src/commands/coverage_command.dart
+++ b/sk_sidekick/lib/src/commands/coverage_command.dart
@@ -1,0 +1,73 @@
+import 'package:sidekick_core/sidekick_core.dart';
+
+class CoverageCommand extends Command {
+  @override
+  String get description => 'Runs code coverage for a single file or package';
+
+  @override
+  String get name => 'coverage';
+
+  @override
+  Future<void> run() async {
+    if (!_isPubGlobalInstalled('coverage')) {
+      dart(['pub', 'global', 'activate', 'coverage']);
+    }
+
+    final package = () {
+      try {
+        return DartPackage.fromArgResults(argResults!);
+      } catch (e) {
+        return null;
+      }
+    }();
+    if (package != null) {
+      _runCoverage(package);
+      return;
+    } else {
+      final file = File(argResults!.rest.first);
+      if (!file.existsSync()) {
+        throw 'Test file does not exist: ${file.path}';
+      }
+      final packageDir = file.parent
+          .findParent((dir) => DartPackage.fromDirectory(dir) != null);
+      if (packageDir == null) {
+        throw '${file.path} is not within a dart package (could not find pubspec.yaml)';
+      }
+      final package = DartPackage.fromDirectory(packageDir)!;
+      print(package);
+      _runCoverage(package, file: file);
+    }
+  }
+}
+
+void _runCoverage(DartPackage package, {File? file}) {
+  final coverageDir = package.root.directory('coverage');
+  if (coverageDir.existsSync()) {
+    coverageDir.deleteSync(recursive: true);
+  }
+
+  dart(
+    [
+      'pub',
+      'global',
+      'run',
+      'coverage:test_with_coverage',
+      if (file != null) file.absolute.path,
+    ],
+    workingDirectory: package.root,
+  );
+
+  'genhtml coverage/lcov.info -o coverage'
+      .start(workingDirectory: package.root.path);
+  'open coverage/index.html'.start(workingDirectory: package.root.path);
+}
+
+bool _isPubGlobalInstalled(String packageName) {
+  final p = Progress.capture();
+  dart(['pub', 'global', 'list'], progress: p);
+  final output = p.lines.join('\n');
+  final regex = RegExp(r'(.+) \d.+');
+  final matches = regex.allMatches(output);
+  final packages = matches.map((m) => m.group(1)!).toList();
+  return packages.contains(packageName);
+}

--- a/sk_sidekick/lib/src/commands/coverage_command.dart
+++ b/sk_sidekick/lib/src/commands/coverage_command.dart
@@ -12,6 +12,13 @@ class CoverageCommand extends Command {
     if (!_isPubGlobalInstalled('coverage')) {
       dart(['pub', 'global', 'activate', 'coverage']);
     }
+    if (!isProgramInstalled('genhtml')) {
+      if (Platform.isMacOS) {
+        'brew install lcov'.run;
+      } else {
+        throw 'genhtml is not installed. Please install lcov';
+      }
+    }
 
     final package = () {
       try {


### PR DESCRIPTION
Allows generating code coverage for packages and files

For some reason, I can't get the `run with code coverage` button in IntelliJ working. This allows me to quickly generate coverage without remembering all the commands.
