### PR TITLE
Show plugin version during install

### DIFF
--- a/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
@@ -136,11 +136,17 @@ class InstallPluginCommand extends Command {
     }
 
     // get installer dependencies
-    sidekickDartRuntime.dart(
-      ['pub', 'get'],
-      workingDirectory: workingDir,
-      progress: Progress.printStdErr(),
-    );
+    final capture = Progress.capture();
+    try {
+      sidekickDartRuntime.dart(
+        ['pub', 'get'],
+        workingDirectory: workingDir,
+        progress: capture,
+      );
+    } catch (e) {
+      printerr(red(capture.lines.join('\n')));
+      rethrow;
+    }
 
     final pluginInstallerProtocolVersion = VersionChecker.getResolvedVersion(
       pluginInstallerCode,

--- a/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
@@ -109,8 +109,8 @@ class InstallPluginCommand extends Command {
       throw "Package directory doesn't exist";
     }
 
-    final pluginName = DartPackage.fromDirectory(pluginInstallerDir)?.name;
-    if (pluginName == null) {
+    final plugin = DartPackage.fromDirectory(pluginInstallerDir);
+    if (plugin == null) {
       throw 'installer package at $pluginInstallerDir is '
           'not a valid dart package';
     }
@@ -119,9 +119,10 @@ class InstallPluginCommand extends Command {
     final target = SidekickContext.sidekickPackage;
     // Important! workingDir has to be within the target package, so it can
     // lookup information with SidekickContext
-    final workingDir = target.root.directory('build/plugins/$pluginName');
+    final workingDir = target.root.directory('build/plugins/${plugin.name}');
 
-    print('Preparing $pluginName installer...');
+    final pluginPubspec = PubSpec.fromFile(plugin.pubspec.absolute.path);
+    print('Preparing ${plugin.name}:${pluginPubspec.version} installer...');
     // copy installer from cache into build dir. We should not manipulate anything in the cache
     if (workingDir.existsSync()) {
       workingDir.deleteSync(recursive: true);
@@ -187,7 +188,9 @@ class InstallPluginCommand extends Command {
       }
     }
 
-    print(white('Executing installer $pluginName...'));
+    print(
+      white('Executing installer ${plugin.name}:${pluginPubspec.version}...'),
+    );
     // Execute installer. Requires a tool/install.dart file to execute
     final installScript = workingDir.file('tool/install.dart');
     if (!installScript.existsSync()) {
@@ -199,7 +202,9 @@ class InstallPluginCommand extends Command {
     );
 
     print(
-      green('Installed $pluginName for ${target.cliName}'),
+      green(
+        'Installed ${plugin.name}:${pluginPubspec.version} for ${target.cliName}',
+      ),
     );
 
     // Cleanup


### PR DESCRIPTION
I'm currently running into errors during plugin install on ci (https://github.com/phntmxyz/sidekick/actions/runs/3981484188/jobs/6825298249). I have no idea what's wrong, it works well for me locally.

This PR helps further debug plugin installation issues:
- print the exact version of the plugin that was installed
- show pub get errors