### PR TITLE
Breaking: `flutter` and `dart` throw by default when failing

### DIFF
--- a/sidekick_core/lib/src/commands/analyze_command.dart
+++ b/sidekick_core/lib/src/commands/analyze_command.dart
@@ -11,10 +11,10 @@ class DartAnalyzeCommand extends ForwardCommand {
   @override
   Future<void> run() async {
     // running in root of project, includes all packages
-    final exitCode = dart(
+    exitCode = dart(
       ['analyze', ...argResults!.arguments],
       workingDirectory: SidekickContext.projectRoot,
+      nothrow: true,
     );
-    exit(exitCode);
   }
 }

--- a/sidekick_core/lib/src/commands/dart_command.dart
+++ b/sidekick_core/lib/src/commands/dart_command.dart
@@ -12,6 +12,6 @@ class DartCommand extends ForwardCommand {
 
   @override
   Future<void> run() async {
-    exitCode = dart(argResults!.arguments);
+    exitCode = dart(argResults!.arguments, nothrow: true);
   }
 }

--- a/sidekick_core/lib/src/commands/deps_command.dart
+++ b/sidekick_core/lib/src/commands/deps_command.dart
@@ -109,7 +109,7 @@ class DepsCommand extends Command {
     dartOrFlutter(
       ['pub', 'get'],
       workingDirectory: packageDir,
-      errorMessage: (_) =>
+      throwOnError: (_) =>
           'Failed to get dependencies for package ${packageDir.path}',
     );
     print("\n");

--- a/sidekick_core/lib/src/commands/deps_command.dart
+++ b/sidekick_core/lib/src/commands/deps_command.dart
@@ -105,17 +105,13 @@ class DepsCommand extends Command {
   void _getDependencies(DartPackage package) {
     print(yellow('=== package ${package.name} ==='));
     final packageDir = package.root;
-    final int exitCode;
-    if (package.isFlutterPackage) {
-      exitCode =
-          flutter(['pub', 'get'], workingDirectory: packageDir, nothrow: true);
-    } else {
-      exitCode =
-          dart(['pub', 'get'], workingDirectory: packageDir, nothrow: true);
-    }
-    if (exitCode != 0) {
-      throw "Failed to get dependencies for package ${packageDir.path}";
-    }
+    final dartOrFlutter = package.isFlutterPackage ? flutter : dart;
+    dartOrFlutter(
+      ['pub', 'get'],
+      workingDirectory: packageDir,
+      errorMessage: (_) =>
+          'Failed to get dependencies for package ${packageDir.path}',
+    );
     print("\n");
   }
 }

--- a/sidekick_core/lib/src/commands/deps_command.dart
+++ b/sidekick_core/lib/src/commands/deps_command.dart
@@ -104,14 +104,17 @@ class DepsCommand extends Command {
 
   void _getDependencies(DartPackage package) {
     print(yellow('=== package ${package.name} ==='));
+    final packageDir = package.root;
     final int exitCode;
     if (package.isFlutterPackage) {
-      exitCode = flutter(['packages', 'get'], workingDirectory: package.root);
+      exitCode =
+          flutter(['pub', 'get'], workingDirectory: packageDir, nothrow: true);
     } else {
-      exitCode = dart(['pub', 'get'], workingDirectory: package.root);
+      exitCode =
+          dart(['pub', 'get'], workingDirectory: packageDir, nothrow: true);
     }
     if (exitCode != 0) {
-      throw "Failed to get dependencies for package ${package.root.path}";
+      throw "Failed to get dependencies for package ${packageDir.path}";
     }
     print("\n");
   }

--- a/sidekick_core/lib/src/commands/deps_command.dart
+++ b/sidekick_core/lib/src/commands/deps_command.dart
@@ -109,7 +109,7 @@ class DepsCommand extends Command {
     dartOrFlutter(
       ['pub', 'get'],
       workingDirectory: packageDir,
-      throwOnError: (_) =>
+      throwOnError: () =>
           'Failed to get dependencies for package ${packageDir.path}',
     );
     print("\n");

--- a/sidekick_core/lib/src/commands/flutter_command.dart
+++ b/sidekick_core/lib/src/commands/flutter_command.dart
@@ -19,7 +19,7 @@ class FlutterCommand extends ForwardCommand {
       // for backwards compatibility link to the previous required flutter_wrapper location
       try {
         // ignore: deprecated_member_use_from_same_package
-        exitCode = flutterw(args);
+        exitCode = flutterw(args, nothrow: true);
         printerr("Sidekick Warning: ${original.message}");
         // success with flutterw, immediately return
         return;

--- a/sidekick_core/lib/src/commands/flutter_command.dart
+++ b/sidekick_core/lib/src/commands/flutter_command.dart
@@ -14,7 +14,7 @@ class FlutterCommand extends ForwardCommand {
   Future<void> run() async {
     final args = argResults!.arguments;
     try {
-      exitCode = flutter(args);
+      exitCode = flutter(args, nothrow: true);
     } on FlutterSdkNotSetException catch (original) {
       // for backwards compatibility link to the previous required flutter_wrapper location
       try {

--- a/sidekick_core/lib/src/commands/update_command.dart
+++ b/sidekick_core/lib/src/commands/update_command.dart
@@ -92,46 +92,46 @@ class UpdateCommand extends Command {
       nothrow: true,
     );
   }
-}
 
-/// Runs the update script `update_sidekick_cli.dart` in a new process using
-/// the `sidekick_core` package at the exact version that is specified in
-/// pubspec.lock
-///
-/// The current process - running `sidekick update` - can't access code of other
-/// version of sidekick_core. Dependencies can't be changed at runtime.
-/// This workaround allows accessing any version of sidekick_core.
-///
-/// Make sure to update the sidekick_core dependency before starting this
-/// process.
-void startUpdateScriptProcess(Version from, Version to) {
-  // it's important that we put the update script within the sidekick package,
-  // so SidekickContext can pick it up
-  final updateScript =
-      SidekickContext.sidekickPackage.buildDir.file('update.dart')
-        ..createSync(recursive: true)
-        ..writeAsStringSync('''
-  import 'package:sidekick_core/src/update_sidekick_cli.dart' as update;
-  Future<void> main(List<String> args) async {
+  /// Runs the update script `update_sidekick_cli.dart` in a new process using
+  /// the `sidekick_core` package at the exact version that is specified in
+  /// pubspec.lock
+  ///
+  /// The current process - running `sidekick update` - can't access code of other
+  /// version of sidekick_core. Dependencies can't be changed at runtime.
+  /// This workaround allows accessing any version of sidekick_core.
+  ///
+  /// Make sure to update the sidekick_core dependency before starting this
+  /// process.
+  void startUpdateScriptProcess(Version from, Version to) {
+    // it's important that we put the update script within the sidekick package,
+    // so SidekickContext can pick it up
+    final updateScript =
+        SidekickContext.sidekickPackage.buildDir.file('update.dart')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+import 'package:sidekick_core/src/update_sidekick_cli.dart' as update;
+Future<void> main(List<String> args) async {
   await update.main(args);
-  }
+}
   ''');
-  try {
-    // Do not change the arguments in a breaking way. The `update_sidekick_cli.dart`
-    // script will be called from another sidekick_core version. Changes will break
-    // the update process.
-    // Only add parameters, never remove any.
-    _dartCommand(
-      [
-        updateScript.path,
-        SidekickContext.cliName,
-        from.canonicalizedVersion,
-        to.canonicalizedVersion,
-      ],
-      progress: Progress.print(),
-    );
-  } finally {
-    updateScript.deleteSync();
+    try {
+      // Do not change the arguments in a breaking way. The `update_sidekick_cli.dart`
+      // script will be called from another sidekick_core version. Changes will break
+      // the update process.
+      // Only add parameters, never remove any.
+      _dartCommand(
+        [
+          updateScript.path,
+          SidekickContext.cliName,
+          from.canonicalizedVersion,
+          to.canonicalizedVersion,
+        ],
+        progress: Progress.print(),
+      );
+    } finally {
+      updateScript.deleteSync();
+    }
   }
 }
 

--- a/sidekick_core/lib/src/commands/update_command.dart
+++ b/sidekick_core/lib/src/commands/update_command.dart
@@ -79,61 +79,59 @@ class UpdateCommand extends Command {
       pubspecKeys: ['dependencies', 'sidekick_core'],
       newMinimumVersion: to,
     );
-    try {
-      _dartCommand(
-        ['pub', 'get'],
-        workingDirectory: SidekickContext.sidekickPackage.root,
-        progress: Progress.devNull(),
-      );
-    } catch (e) {
+    _dartCommand(
+      ['pub', 'get'],
+      workingDirectory: SidekickContext.sidekickPackage.root,
+      progress: Progress.devNull(),
       // This pub get is a nice to have, and it doesn't matter if it fails or
       // not. It may fail when the Dart SDK version has been updated, because
       // `_dartCommand` still uses the "old" Dart SDK.
       // The new SDK will be downloaded with the next execution.
 
       // For all other errors: They become visible the next time the cli is executed
-    }
+      nothrow: true,
+    );
   }
+}
 
-  /// Runs the update script `update_sidekick_cli.dart` in a new process using
-  /// the `sidekick_core` package at the exact version that is specified in
-  /// pubspec.lock
-  ///
-  /// The current process - running `sidekick update` - can't access code of other
-  /// version of sidekick_core. Dependencies can't be changed at runtime.
-  /// This workaround allows accessing any version of sidekick_core.
-  ///
-  /// Make sure to update the sidekick_core dependency before starting this
-  /// process.
-  void startUpdateScriptProcess(Version from, Version to) {
-    // it's important that we put the update script within the sidekick package,
-    // so SidekickContext can pick it up
-    final updateScript =
-        SidekickContext.sidekickPackage.buildDir.file('update.dart')
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
+/// Runs the update script `update_sidekick_cli.dart` in a new process using
+/// the `sidekick_core` package at the exact version that is specified in
+/// pubspec.lock
+///
+/// The current process - running `sidekick update` - can't access code of other
+/// version of sidekick_core. Dependencies can't be changed at runtime.
+/// This workaround allows accessing any version of sidekick_core.
+///
+/// Make sure to update the sidekick_core dependency before starting this
+/// process.
+void startUpdateScriptProcess(Version from, Version to) {
+  // it's important that we put the update script within the sidekick package,
+  // so SidekickContext can pick it up
+  final updateScript =
+      SidekickContext.sidekickPackage.buildDir.file('update.dart')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
   import 'package:sidekick_core/src/update_sidekick_cli.dart' as update;
   Future<void> main(List<String> args) async {
   await update.main(args);
   }
   ''');
-    try {
-      // Do not change the arguments in a breaking way. The `update_sidekick_cli.dart`
-      // script will be called from another sidekick_core version. Changes will break
-      // the update process.
-      // Only add parameters, never remove any.
-      _dartCommand(
-        [
-          updateScript.path,
-          SidekickContext.cliName,
-          from.canonicalizedVersion,
-          to.canonicalizedVersion,
-        ],
-        progress: Progress.print(),
-      );
-    } finally {
-      updateScript.deleteSync();
-    }
+  try {
+    // Do not change the arguments in a breaking way. The `update_sidekick_cli.dart`
+    // script will be called from another sidekick_core version. Changes will break
+    // the update process.
+    // Only add parameters, never remove any.
+    _dartCommand(
+      [
+        updateScript.path,
+        SidekickContext.cliName,
+        from.canonicalizedVersion,
+        to.canonicalizedVersion,
+      ],
+      progress: Progress.print(),
+    );
+  } finally {
+    updateScript.deleteSync();
   }
 }
 
@@ -165,6 +163,7 @@ void Function(
   List<String> args, {
   Progress? progress,
   Directory? workingDirectory,
+  bool nothrow,
 }) get _dartCommand {
   return sidekickDartRuntime.isDownloaded() ? sidekickDartRuntime.dart : dart;
 }

--- a/sidekick_core/lib/src/dart.dart
+++ b/sidekick_core/lib/src/dart.dart
@@ -17,7 +17,7 @@ int dart(
   Directory? workingDirectory,
   dcli.Progress? progress,
   bool nothrow = false,
-  String Function(int code)? throwOnError,
+  String Function()? throwOnError,
 }) {
   bool flutterwLegacyMode = false;
 
@@ -76,7 +76,7 @@ int dart(
   final exitCode = process.exitCode ?? -1;
 
   if (exitCode != 0 && throwOnError != null) {
-    throw throwOnError(exitCode);
+    throw throwOnError();
   }
 
   return exitCode;
@@ -107,7 +107,7 @@ int systemDart(
   Directory? workingDirectory,
   dcli.Progress? progress,
   bool nothrow = false,
-  String Function(int code)? throwOnError,
+  String Function()? throwOnError,
 }) {
   final systemDartExecutablePath = systemDartExecutable();
   if (systemDartExecutablePath == null) {
@@ -126,7 +126,7 @@ int systemDart(
   final exitCode = process.exitCode ?? -1;
 
   if (exitCode != 0 && throwOnError != null) {
-    throw throwOnError(exitCode);
+    throw throwOnError();
   }
 
   return exitCode;

--- a/sidekick_core/lib/src/dart.dart
+++ b/sidekick_core/lib/src/dart.dart
@@ -5,6 +5,10 @@ import 'package:sidekick_core/sidekick_core.dart';
 /// https://github.com/passsy/flutter_wrapper
 ///
 /// Makes sure flutterw is executed beforehand to download the dart-sdk
+///
+/// Set [nothrow] to true to ignore errors when executing the dart command.
+/// The exit code will still be non-zero if the command failed and the method
+/// will still throw if the Dart SDK was not set in [initializeSidekick]
 int dart(
   List<String> args, {
   Directory? workingDirectory,
@@ -84,6 +88,10 @@ class DartSdkNotSetException implements Exception {
 }
 
 /// Executes the system dart cli which is globally available on PATH
+///
+/// Set [nothrow] to true to ignore errors when executing the dart command.
+/// The exit code will still be non-zero if the command failed and the method
+/// will still throw if there is no Dart SDK on PATH
 int systemDart(
   List<String> args, {
   Directory? workingDirectory,

--- a/sidekick_core/lib/src/dart.dart
+++ b/sidekick_core/lib/src/dart.dart
@@ -57,13 +57,8 @@ int dart(
     throw DartSdkNotSetException();
   }
 
-  final dart = () {
-    if (Platform.isWindows) {
-      return sdk!.file('bin/dart.exe');
-    } else {
-      return sdk!.file('bin/dart');
-    }
-  }();
+  final dart =
+      Platform.isWindows ? sdk.file('bin/dart.exe') : sdk.file('bin/dart');
 
   final process = dcli.startFromArgs(
     dart.path,
@@ -80,7 +75,7 @@ int dart(
 
   final exitCode = process.exitCode ?? -1;
 
-  if (throwOnError != null) {
+  if (exitCode != 0 && throwOnError != null) {
     throw throwOnError(exitCode);
   }
 
@@ -130,7 +125,7 @@ int systemDart(
 
   final exitCode = process.exitCode ?? -1;
 
-  if (throwOnError != null) {
+  if (exitCode != 0 && throwOnError != null) {
     throw throwOnError(exitCode);
   }
 

--- a/sidekick_core/lib/src/dart.dart
+++ b/sidekick_core/lib/src/dart.dart
@@ -9,6 +9,7 @@ int dart(
   List<String> args, {
   Directory? workingDirectory,
   dcli.Progress? progress,
+  bool nothrow = false,
 }) {
   bool flutterwLegacyMode = false;
 
@@ -19,7 +20,7 @@ int dart(
       if (!embeddedSdk.existsSync()) {
         // Flutter SDK is not fully initialized, the Dart SDK not yet downloaded
         // Execute flutter_tool to download the embedded dart runtime
-        flutter([], workingDirectory: workingDirectory);
+        flutter([], workingDirectory: workingDirectory, nothrow: true);
       }
       if (embeddedSdk.existsSync()) {
         sdk = embeddedSdk;
@@ -35,7 +36,7 @@ int dart(
           // Flutter SDK is not fully initialized, the Dart SDK not yet downloaded
           // Execute flutter_tool to download the embedded dart runtime
           // ignore: deprecated_member_use_from_same_package
-          flutterw([], workingDirectory: workingDirectory);
+          flutterw([], workingDirectory: workingDirectory, nothrow: true);
         }
         if (embeddedSdk?.existsSync() == true) {
           sdk = embeddedSdk;
@@ -61,7 +62,7 @@ int dart(
     args,
     workingDirectory: workingDirectory?.path ?? entryWorkingDirectory.path,
     progress: progress,
-    nothrow: true,
+    nothrow: nothrow,
     terminal: progress == null,
   );
 
@@ -87,6 +88,7 @@ int systemDart(
   List<String> args, {
   Directory? workingDirectory,
   dcli.Progress? progress,
+  bool nothrow = false,
 }) {
   final systemDartExecutablePath = systemDartExecutable();
   if (systemDartExecutablePath == null) {
@@ -99,6 +101,7 @@ int systemDart(
     workingDirectory: workingDirectory?.path ?? entryWorkingDirectory.path,
     progress: progress,
     terminal: progress == null,
+    nothrow: nothrow,
   );
 
   return process.exitCode ?? -1;

--- a/sidekick_core/lib/src/dart.dart
+++ b/sidekick_core/lib/src/dart.dart
@@ -10,14 +10,14 @@ import 'package:sidekick_core/sidekick_core.dart';
 /// The exit code will still be non-zero if the command failed and the method
 /// will still throw if the Dart SDK was not set in [initializeSidekick]
 ///
-/// If [errorMessage] is given and the command returns a non-zero exit code,
-/// the result of [errorMessage] will be thrown regardless of [nothrow]
+/// If [throwOnError] is given and the command returns a non-zero exit code,
+/// the result of [throwOnError] will be thrown regardless of [nothrow]
 int dart(
   List<String> args, {
   Directory? workingDirectory,
   dcli.Progress? progress,
   bool nothrow = false,
-  String Function(int code)? errorMessage,
+  String Function(int code)? throwOnError,
 }) {
   bool flutterwLegacyMode = false;
 
@@ -70,7 +70,7 @@ int dart(
     args,
     workingDirectory: workingDirectory?.path ?? entryWorkingDirectory.path,
     progress: progress,
-    nothrow: nothrow || errorMessage != null,
+    nothrow: nothrow || throwOnError != null,
     terminal: progress == null,
   );
 
@@ -80,8 +80,8 @@ int dart(
 
   final exitCode = process.exitCode ?? -1;
 
-  if (errorMessage != null) {
-    throw errorMessage(exitCode);
+  if (throwOnError != null) {
+    throw throwOnError(exitCode);
   }
 
   return exitCode;
@@ -105,14 +105,14 @@ class DartSdkNotSetException implements Exception {
 /// will still throw if there is no Dart SDK on PATH
 ///
 ///
-/// If [errorMessage] is given and the command returns a non-zero exit code,
-/// the result of [errorMessage] will be thrown regardless of [nothrow]
+/// If [throwOnError] is given and the command returns a non-zero exit code,
+/// the result of [throwOnError] will be thrown regardless of [nothrow]
 int systemDart(
   List<String> args, {
   Directory? workingDirectory,
   dcli.Progress? progress,
   bool nothrow = false,
-  String Function(int code)? errorMessage,
+  String Function(int code)? throwOnError,
 }) {
   final systemDartExecutablePath = systemDartExecutable();
   if (systemDartExecutablePath == null) {
@@ -125,13 +125,13 @@ int systemDart(
     workingDirectory: workingDirectory?.path ?? entryWorkingDirectory.path,
     progress: progress,
     terminal: progress == null,
-    nothrow: nothrow || errorMessage != null,
+    nothrow: nothrow || throwOnError != null,
   );
 
   final exitCode = process.exitCode ?? -1;
 
-  if (errorMessage != null) {
-    throw errorMessage(exitCode);
+  if (throwOnError != null) {
+    throw throwOnError(exitCode);
   }
 
   return exitCode;

--- a/sidekick_core/lib/src/dart_runtime.dart
+++ b/sidekick_core/lib/src/dart_runtime.dart
@@ -42,6 +42,7 @@ class SidekickDartRuntime {
     List<String> args, {
     Directory? workingDirectory,
     dcli.Progress? progress,
+    bool nothrow = false,
   }) {
     final binDir = dartSdkPath.directory('bin');
     final dart = () {
@@ -57,6 +58,7 @@ class SidekickDartRuntime {
       args,
       workingDirectory: workingDirectory?.path ?? entryWorkingDirectory.path,
       progress: progress,
+      nothrow: nothrow,
       terminal: progress == null,
     );
   }

--- a/sidekick_core/lib/src/flutter.dart
+++ b/sidekick_core/lib/src/flutter.dart
@@ -4,6 +4,10 @@ import 'package:dcli/dcli.dart' as dcli;
 import 'package:sidekick_core/sidekick_core.dart';
 
 /// Executes Flutter command from Flutter SDK set in [flutterSdk]
+///
+/// Set [nothrow] to true to ignore errors when executing the flutter command.
+/// The exit code will still be non-zero if the command failed and the method
+/// will still throw if the Flutter SDK was not set in [initializeSidekick]
 int flutter(
   List<String> args, {
   Directory? workingDirectory,

--- a/sidekick_core/lib/src/flutter.dart
+++ b/sidekick_core/lib/src/flutter.dart
@@ -9,14 +9,14 @@ import 'package:sidekick_core/sidekick_core.dart';
 /// The exit code will still be non-zero if the command failed and the method
 /// will still throw if the Flutter SDK was not set in [initializeSidekick]
 ///
-/// If [errorMessage] is given and the command returns a non-zero exit code,
-/// the result of [errorMessage] will be thrown regardless of [nothrow]
+/// If [throwOnError] is given and the command returns a non-zero exit code,
+/// the result of [throwOnError] will be thrown regardless of [nothrow]
 int flutter(
   List<String> args, {
   Directory? workingDirectory,
   dcli.Progress? progress,
   bool nothrow = false,
-  String Function(int code)? errorMessage,
+  String Function(int code)? throwOnError,
 }) {
   final workingDir =
       workingDirectory?.absolute ?? entryWorkingDirectory.absolute;
@@ -37,15 +37,15 @@ int flutter(
     Platform.isWindows ? 'bash' : sdk.file('bin/flutter').path,
     [if (Platform.isWindows) sdk.file('bin/flutter.exe').path, ...args],
     workingDirectory: workingDir.path,
-    nothrow: nothrow || errorMessage != null,
+    nothrow: nothrow || throwOnError != null,
     progress: progress,
     terminal: progress == null,
   );
 
   final exitCode = process.exitCode ?? -1;
 
-  if (errorMessage != null) {
-    throw errorMessage(exitCode);
+  if (throwOnError != null) {
+    throw throwOnError(exitCode);
   }
 
   return exitCode;

--- a/sidekick_core/lib/src/flutter.dart
+++ b/sidekick_core/lib/src/flutter.dart
@@ -44,7 +44,7 @@ int flutter(
 
   final exitCode = process.exitCode ?? -1;
 
-  if (throwOnError != null) {
+  if (exitCode != 0 && throwOnError != null) {
     throw throwOnError(exitCode);
   }
 

--- a/sidekick_core/lib/src/flutter.dart
+++ b/sidekick_core/lib/src/flutter.dart
@@ -8,6 +8,7 @@ int flutter(
   List<String> args, {
   Directory? workingDirectory,
   dcli.Progress? progress,
+  bool nothrow = false,
 }) {
   final workingDir =
       workingDirectory?.absolute ?? entryWorkingDirectory.absolute;
@@ -39,7 +40,7 @@ int flutter(
       sdk.file('bin/flutter').path,
       args,
       workingDirectory: workingDir.path,
-      nothrow: true,
+      nothrow: nothrow,
       progress: progress,
       terminal: progress == null,
     );

--- a/sidekick_core/lib/src/flutter.dart
+++ b/sidekick_core/lib/src/flutter.dart
@@ -16,7 +16,7 @@ int flutter(
   Directory? workingDirectory,
   dcli.Progress? progress,
   bool nothrow = false,
-  String Function(int code)? throwOnError,
+  String Function()? throwOnError,
 }) {
   final workingDir =
       workingDirectory?.absolute ?? entryWorkingDirectory.absolute;
@@ -45,7 +45,7 @@ int flutter(
   final exitCode = process.exitCode ?? -1;
 
   if (exitCode != 0 && throwOnError != null) {
-    throw throwOnError(exitCode);
+    throw throwOnError();
   }
 
   return exitCode;

--- a/sidekick_core/lib/src/flutterw.dart
+++ b/sidekick_core/lib/src/flutterw.dart
@@ -19,6 +19,7 @@ int flutterw(
   List<String> args, {
   Directory? workingDirectory,
   dcli.Progress? progress,
+  bool nothrow = false,
 }) {
   final flutterw = findFlutterwLocation();
   if (flutterw == null) {
@@ -32,7 +33,7 @@ int flutterw(
       'bash',
       [flutterw.path, ...args],
       workingDirectory: workingDir.path,
-      nothrow: true,
+      nothrow: nothrow,
       progress: progress,
       terminal: progress == null,
     );
@@ -42,7 +43,7 @@ int flutterw(
       flutterw.path,
       args,
       workingDirectory: workingDir.path,
-      nothrow: true,
+      nothrow: nothrow,
       progress: progress,
       terminal: progress == null,
     );

--- a/sidekick_core/lib/src/flutterw.dart
+++ b/sidekick_core/lib/src/flutterw.dart
@@ -47,7 +47,7 @@ int flutterw(
 
   final exitCode = process.exitCode ?? -1;
 
-  if (throwOnError != null) {
+  if (exitCode != 0 && throwOnError != null) {
     throw throwOnError(exitCode);
   }
 

--- a/sidekick_core/lib/src/flutterw.dart
+++ b/sidekick_core/lib/src/flutterw.dart
@@ -27,7 +27,7 @@ int flutterw(
   Directory? workingDirectory,
   dcli.Progress? progress,
   bool nothrow = false,
-  String Function(int code)? throwOnError,
+  String Function()? throwOnError,
 }) {
   final flutterw = findFlutterwLocation();
   if (flutterw == null) {
@@ -48,7 +48,7 @@ int flutterw(
   final exitCode = process.exitCode ?? -1;
 
   if (exitCode != 0 && throwOnError != null) {
-    throw throwOnError(exitCode);
+    throw throwOnError();
   }
 
   return exitCode;

--- a/sidekick_core/lib/src/flutterw.dart
+++ b/sidekick_core/lib/src/flutterw.dart
@@ -19,15 +19,15 @@ File? findFlutterwLocation() {
 /// The exit code will still be non-zero if the command failed and the method
 /// will still throw if no flutterw can be found
 ///
-/// If [errorMessage] is given and the command returns a non-zero exit code,
-/// the result of [errorMessage] will be thrown regardless of [nothrow]
+/// If [throwOnError] is given and the command returns a non-zero exit code,
+/// the result of [throwOnError] will be thrown regardless of [nothrow]
 @Deprecated('Use flutter() instead')
 int flutterw(
   List<String> args, {
   Directory? workingDirectory,
   dcli.Progress? progress,
   bool nothrow = false,
-  String Function(int code)? errorMessage,
+  String Function(int code)? throwOnError,
 }) {
   final flutterw = findFlutterwLocation();
   if (flutterw == null) {
@@ -40,15 +40,15 @@ int flutterw(
     Platform.isWindows ? 'bash' : flutterw.path,
     [if (Platform.isWindows) flutterw.path, ...args],
     workingDirectory: workingDir.path,
-    nothrow: nothrow || errorMessage != null,
+    nothrow: nothrow || throwOnError != null,
     progress: progress,
     terminal: progress == null,
   );
 
   final exitCode = process.exitCode ?? -1;
 
-  if (errorMessage != null) {
-    throw errorMessage(exitCode);
+  if (throwOnError != null) {
+    throw throwOnError(exitCode);
   }
 
   return exitCode;

--- a/sidekick_core/lib/src/flutterw.dart
+++ b/sidekick_core/lib/src/flutterw.dart
@@ -18,12 +18,16 @@ File? findFlutterwLocation() {
 /// Set [nothrow] to true to ignore errors when executing the flutterw command.
 /// The exit code will still be non-zero if the command failed and the method
 /// will still throw if no flutterw can be found
+///
+/// If [errorMessage] is given and the command returns a non-zero exit code,
+/// the result of [errorMessage] will be thrown regardless of [nothrow]
 @Deprecated('Use flutter() instead')
 int flutterw(
   List<String> args, {
   Directory? workingDirectory,
   dcli.Progress? progress,
   bool nothrow = false,
+  String Function(int code)? errorMessage,
 }) {
   final flutterw = findFlutterwLocation();
   if (flutterw == null) {
@@ -32,27 +36,22 @@ int flutterw(
   final workingDir =
       workingDirectory?.absolute ?? entryWorkingDirectory.absolute;
 
-  if (Platform.isWindows) {
-    final process = dcli.startFromArgs(
-      'bash',
-      [flutterw.path, ...args],
-      workingDirectory: workingDir.path,
-      nothrow: nothrow,
-      progress: progress,
-      terminal: progress == null,
-    );
-    return process.exitCode ?? -1;
-  } else {
-    final process = dcli.startFromArgs(
-      flutterw.path,
-      args,
-      workingDirectory: workingDir.path,
-      nothrow: nothrow,
-      progress: progress,
-      terminal: progress == null,
-    );
-    return process.exitCode ?? -1;
+  final process = dcli.startFromArgs(
+    Platform.isWindows ? 'bash' : flutterw.path,
+    [if (Platform.isWindows) flutterw.path, ...args],
+    workingDirectory: workingDir.path,
+    nothrow: nothrow || errorMessage != null,
+    progress: progress,
+    terminal: progress == null,
+  );
+
+  final exitCode = process.exitCode ?? -1;
+
+  if (errorMessage != null) {
+    throw errorMessage(exitCode);
   }
+
+  return exitCode;
 }
 
 /// Thrown when flutterw is not found

--- a/sidekick_core/lib/src/flutterw.dart
+++ b/sidekick_core/lib/src/flutterw.dart
@@ -14,6 +14,10 @@ File? findFlutterwLocation() {
 /// Executes Flutter CLI (flutter_tool) via flutter_wrapper
 ///
 /// https://github.com/passsy/flutter_wrapper
+///
+/// Set [nothrow] to true to ignore errors when executing the flutterw command.
+/// The exit code will still be non-zero if the command failed and the method
+/// will still throw if no flutterw can be found
 @Deprecated('Use flutter() instead')
 int flutterw(
   List<String> args, {

--- a/sidekick_core/test/dart_command_test.dart
+++ b/sidekick_core/test/dart_command_test.dart
@@ -39,4 +39,16 @@ void main() {
       await runner.run(['dart']);
     });
   });
+
+  test('dart command sets exit code when command fails', () async {
+    await insideFakeProjectWithSidekick((dir) async {
+      final runner = initializeSidekick(
+        name: 'dash',
+        dartSdkPath: fakeFailingDartSdk().path,
+      );
+      runner.addCommand(DartCommand());
+      await runner.run(['dart', 'plz', 'fail']);
+      expect(exitCode, isNonZero);
+    });
+  });
 }

--- a/sidekick_core/test/dart_test.dart
+++ b/sidekick_core/test/dart_test.dart
@@ -59,5 +59,28 @@ void main() {
         });
       },
     );
+
+    test(
+      'throws given message when command fails',
+      () async {
+        await insideFakeProjectWithSidekick((_) async {
+          final runner = initializeSidekick(
+            name: 'dash',
+            dartSdkPath: fakeFailingDartSdk().path,
+          );
+          runner.addCommand(
+            DelegatedCommand(
+              name: 'dart',
+              block: () => dart(['fail'], throwOnError: (_) => 'foo'),
+            ),
+          );
+
+          await expectLater(
+            () => runner.run(['dart']),
+            throwsA('foo'),
+          );
+        });
+      },
+    );
   });
 }

--- a/sidekick_core/test/dart_test.dart
+++ b/sidekick_core/test/dart_test.dart
@@ -71,7 +71,7 @@ void main() {
           runner.addCommand(
             DelegatedCommand(
               name: 'dart',
-              block: () => dart(['fail'], throwOnError: (_) => 'foo'),
+              block: () => dart(['fail'], throwOnError: () => 'foo'),
             ),
           );
 

--- a/sidekick_core/test/dart_test.dart
+++ b/sidekick_core/test/dart_test.dart
@@ -1,23 +1,27 @@
 import 'package:dcli/dcli.dart';
 import 'package:dcli/posix.dart';
 import 'package:sidekick_core/sidekick_core.dart';
+import 'package:sidekick_test/sidekick_test.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('systemDartSdkPath', () {
-    test('returns null when dart is not on path', () {
+    final originalPATH = [...PATH];
+    setUp(() {
       final whichPath =
           start('which which', progress: Progress.capture()).firstLine!;
       PATH.where((p) => !whichPath.startsWith(p)).forEach(env.removeFromPATH);
+      addTearDown(() {
+        PATH.forEach(env.removeFromPATH);
+        originalPATH.forEach(env.appendToPATH);
+      });
+    });
 
+    test('returns null when dart is not on path', () {
       expect(systemDartSdkPath(), null);
     });
 
     test('returns correct path when dart is on path', () {
-      final whichPath =
-          start('which which', progress: Progress.capture()).firstLine!;
-      PATH.where((p) => !whichPath.startsWith(p)).forEach(env.removeFromPATH);
-
       final tempDir = Directory.systemTemp.createTempSync();
       addTearDown(() => tempDir.deleteSync(recursive: true));
 
@@ -33,5 +37,27 @@ void main() {
             .resolveSymbolicLinksSync(),
       );
     });
+  });
+
+  group('dart', () {
+    test(
+      'throws by default when command fails',
+      () async {
+        await insideFakeProjectWithSidekick((_) async {
+          final runner = initializeSidekick(
+            name: 'dash',
+            dartSdkPath: fakeFailingDartSdk().path,
+          );
+          runner.addCommand(
+            DelegatedCommand(name: 'dart', block: () => dart(['fail'])),
+          );
+
+          await expectLater(
+            () => runner.run(['dart']),
+            throwsA(isA<RunException>()),
+          );
+        });
+      },
+    );
   });
 }

--- a/sidekick_core/test/flutter_command_test.dart
+++ b/sidekick_core/test/flutter_command_test.dart
@@ -148,4 +148,16 @@ void main() {
       });
     });
   });
+
+  test('flutter command sets exit code when command fails', () async {
+    await insideFakeProjectWithSidekick((dir) async {
+      final runner = initializeSidekick(
+        name: 'dash',
+        flutterSdkPath: fakeFailingFlutterSdk().path,
+      );
+      runner.addCommand(FlutterCommand());
+      await runner.run(['flutter', 'plz', 'fail']);
+      expect(exitCode, isNonZero);
+    });
+  });
 }

--- a/sidekick_core/test/flutter_test.dart
+++ b/sidekick_core/test/flutter_test.dart
@@ -70,5 +70,28 @@ void main() {
         });
       },
     );
+
+    test(
+      'throws given message when command fails',
+      () async {
+        await insideFakeProjectWithSidekick((_) async {
+          final runner = initializeSidekick(
+            name: 'dash',
+            flutterSdkPath: fakeFailingFlutterSdk().path,
+          );
+          runner.addCommand(
+            DelegatedCommand(
+              name: 'flutter',
+              block: () => flutter(['fail'], throwOnError: (_) => 'foo'),
+            ),
+          );
+
+          await expectLater(
+            () => runner.run(['flutter']),
+            throwsA('foo'),
+          );
+        });
+      },
+    );
   });
 }

--- a/sidekick_core/test/flutter_test.dart
+++ b/sidekick_core/test/flutter_test.dart
@@ -1,26 +1,31 @@
 import 'package:dcli/dcli.dart';
 import 'package:dcli/posix.dart';
 import 'package:sidekick_core/sidekick_core.dart';
+import 'package:sidekick_test/sidekick_test.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final tempDir = Directory.systemTemp.createTempSync();
-  final fakeFlutter = tempDir.file('fake_flutter/bin/flutter')
-    ..createSync(recursive: true);
-  chmod(fakeFlutter.path, permission: '755');
-
-  setUp(() {
-    final whichPath =
-        start('which which', progress: Progress.capture()).firstLine!;
-    PATH.where((p) => !whichPath.startsWith(p)).forEach(env.removeFromPATH);
-    env['FLUTTER_ROOT'] = null;
-  });
-
-  tearDownAll(() {
-    tempDir.deleteSync(recursive: true);
-  });
-
   group('systemFlutterSdkPath', () {
+    final tempDir = Directory.systemTemp.createTempSync();
+    final fakeFlutter = tempDir.file('fake_flutter/bin/flutter')
+      ..createSync(recursive: true);
+    chmod(fakeFlutter.path, permission: '755');
+
+    tearDownAll(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    final originalPATH = [...PATH];
+    setUp(() {
+      final whichPath =
+          start('which which', progress: Progress.capture()).firstLine!;
+      PATH.where((p) => !whichPath.startsWith(p)).forEach(env.removeFromPATH);
+      addTearDown(() {
+        PATH.forEach(env.removeFromPATH);
+        originalPATH.forEach(env.appendToPATH);
+      });
+    });
+
     test('returns null when flutter is not on path or env.FLUTTER_ROOT', () {
       expect(systemFlutterSdkPath(), null);
     });
@@ -43,5 +48,27 @@ void main() {
         tempDir.directory('fake_flutter').resolveSymbolicLinksSync(),
       );
     });
+  });
+
+  group('flutter', () {
+    test(
+      'throws by default when command fails',
+      () async {
+        await insideFakeProjectWithSidekick((_) async {
+          final runner = initializeSidekick(
+            name: 'dash',
+            flutterSdkPath: fakeFailingFlutterSdk().path,
+          );
+          runner.addCommand(
+            DelegatedCommand(name: 'flutter', block: () => flutter(['fail'])),
+          );
+
+          await expectLater(
+            () => runner.run(['flutter']),
+            throwsA(isA<RunException>()),
+          );
+        });
+      },
+    );
   });
 }

--- a/sidekick_core/test/flutter_test.dart
+++ b/sidekick_core/test/flutter_test.dart
@@ -82,7 +82,7 @@ void main() {
           runner.addCommand(
             DelegatedCommand(
               name: 'flutter',
-              block: () => flutter(['fail'], throwOnError: (_) => 'foo'),
+              block: () => flutter(['fail'], throwOnError: () => 'foo'),
             ),
           );
 

--- a/sidekick_core/test/init_test.dart
+++ b/sidekick_core/test/init_test.dart
@@ -35,7 +35,7 @@ void main() {
           final runner = initializeSidekick(name: 'dash');
           bool called = false;
           runner.addCommand(
-            _DelegatedCommand(name: 'inside', block: () => called = true),
+            DelegatedCommand(name: 'inside', block: () => called = true),
           );
           await runner.run(['inside', '--version']);
           expect(called, isFalse);
@@ -87,7 +87,7 @@ void main() {
         );
         bool called = false;
         runner.addCommand(
-          _DelegatedCommand(
+          DelegatedCommand(
             name: 'inside',
             block: () {
               called = true;
@@ -105,7 +105,7 @@ void main() {
         final runner = initializeSidekick(name: 'dash', mainProjectPath: '.');
         bool called = false;
         runner.addCommand(
-          _DelegatedCommand(
+          DelegatedCommand(
             name: 'inside',
             block: () {
               called = true;
@@ -125,7 +125,7 @@ void main() {
           final runner = initializeSidekick(name: 'dash', mainProjectPath: '.');
           bool called = false;
           runner.addCommand(
-            _DelegatedCommand(
+            DelegatedCommand(
               name: 'inside',
               block: () {
                 called = true;
@@ -148,7 +148,7 @@ void main() {
           final runner = initializeSidekick(name: 'dash', mainProjectPath: '.');
           bool called = false;
           runner.addCommand(
-            _DelegatedCommand(
+            DelegatedCommand(
               name: 'inside',
               block: () {
                 called = true;
@@ -187,7 +187,7 @@ void main() {
         final runner = initializeSidekick(name: 'dash');
         bool called = false;
         runner.addCommand(
-          _DelegatedCommand(
+          DelegatedCommand(
             name: 'inside',
             block: () {
               called = true;
@@ -206,7 +206,7 @@ void main() {
         final runner = initializeSidekick(name: 'dash');
         bool called = false;
         runner.addCommand(
-          _DelegatedCommand(
+          DelegatedCommand(
             name: 'inside',
             block: () {
               called = true;
@@ -238,7 +238,7 @@ void main() {
         final runner = initializeSidekick(name: 'dash');
         bool called = false;
         runner.addCommand(
-          _DelegatedCommand(
+          DelegatedCommand(
             name: 'inside',
             block: () {
               called = true;
@@ -259,7 +259,7 @@ void main() {
       bool outerCalled = false;
       bool innerCalled = false;
       outerRunner.addCommand(
-        _DelegatedCommand(
+        DelegatedCommand(
           name: 'outer',
           block: () async {
             outerCalled = true;
@@ -275,7 +275,7 @@ void main() {
 
             final innerRunner = initializeSidekick(name: 'innerdash');
             innerRunner.addCommand(
-              _DelegatedCommand(
+              DelegatedCommand(
                 name: 'inner',
                 block: () {
                   innerCalled = true;
@@ -596,24 +596,4 @@ void main() {
       });
     });
   });
-}
-
-class _DelegatedCommand extends Command {
-  _DelegatedCommand({
-    required this.name,
-    required this.block,
-  });
-
-  @override
-  String get description => 'delegated';
-
-  @override
-  final String name;
-
-  final FutureOr<void> Function() block;
-
-  @override
-  Future<void> run() async {
-    await block();
-  }
 }

--- a/sidekick_core/test/sidekick_package_template_test.dart
+++ b/sidekick_core/test/sidekick_package_template_test.dart
@@ -23,7 +23,6 @@ void main() {
         packageLocation: tempDir,
         mainProjectPath: '.',
         shouldSetFlutterSdkPath: true,
-        sidekickCliVersion: Version.none,
       );
 
       template.generate(props);

--- a/sidekick_test/lib/sidekick_test.dart
+++ b/sidekick_test/lib/sidekick_test.dart
@@ -2,5 +2,7 @@
 library sidekick_test;
 
 export 'package:mocktail/mocktail.dart';
+
+export 'src/delegated_command.dart';
 export 'src/fake_sdk.dart';
 export 'src/local_testing.dart';

--- a/sidekick_test/lib/src/delegated_command.dart
+++ b/sidekick_test/lib/src/delegated_command.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+
+import 'package:args/command_runner.dart';
+
+/// Command which only executes the given [block]
+class DelegatedCommand extends Command {
+  DelegatedCommand({
+    required this.name,
+    required this.block,
+  });
+
+  @override
+  String get description => 'delegated';
+
+  @override
+  final String name;
+
+  final FutureOr<void> Function() block;
+
+  @override
+  Future<void> run() async {
+    await block();
+  }
+}

--- a/sidekick_test/lib/src/fake_sdk.dart
+++ b/sidekick_test/lib/src/fake_sdk.dart
@@ -30,6 +30,27 @@ chmod 755 ${dir.absolute.path}/bin/cache/dart-sdk/bin/dart
   return dir;
 }
 
+/// Creates a fake Flutter SDK in temp with a `flutter` executable that
+/// always fails
+Directory fakeFailingFlutterSdk({Directory? directory}) {
+  final Directory dir = directory ??
+      () {
+        final temp = Directory.systemTemp.createTempSync('fake_flutter');
+        addTearDown(() => temp.deleteSync(recursive: true));
+        return temp;
+      }();
+
+  final flutterExe = dir.file('bin/flutter')
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+#!/bin/bash
+echo "fake failing Flutter executable"
+exit 1
+''');
+  dcli.run('chmod 755 ${flutterExe.path}');
+  return dir;
+}
+
 /// Creates a fake Dart SDK with a `dart` executable that does nothing
 Directory fakeDartSdk() {
   final temp = Directory.systemTemp.createTempSync('fake_dart');
@@ -38,6 +59,22 @@ Directory fakeDartSdk() {
   final exe = temp.file('bin/dart')
     ..createSync(recursive: true)
     ..writeAsStringSync('#!/bin/bash\necho "fake Dart executable"');
+  dcli.run('chmod 755 ${exe.path}');
+
+  return temp;
+}
+
+/// Creates a fake Dart SDK with a `dart` executable that always fails
+Directory fakeFailingDartSdk() {
+  final temp = Directory.systemTemp.createTempSync('fake_dart');
+  addTearDown(() => temp.deleteSync(recursive: true));
+
+  final exe = temp.file('bin/dart')
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+#!/bin/bash
+echo "fake throwing Dart executable"
+exit 1''');
   dcli.run('chmod 755 ${exe.path}');
 
   return temp;

--- a/sidekick_test/pubspec.yaml
+++ b/sidekick_test/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
+  args: ^2.1.0
   dartx: ^1.0.0
   dcli: ^1.16.2
   mocktail: ^0.3.0

--- a/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
+++ b/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
@@ -45,7 +45,7 @@ class LockDependenciesCommand extends Command {
     systemDart(
       ['pub', 'get'],
       workingDirectory: package.root,
-      throwOnError: (_) => "Couldn't get dependencies in ${package.root}",
+      throwOnError: () => "Couldn't get dependencies in ${package.root}",
     );
 
     final lockfile = package.lockfile;

--- a/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
+++ b/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
@@ -42,14 +42,11 @@ class LockDependenciesCommand extends Command {
       }
     }
 
-    final pubGet = systemDart(
+    systemDart(
       ['pub', 'get'],
       workingDirectory: package.root,
-      nothrow: true,
+      errorMessage: (_) => "Couldn't get dependencies in ${package.root}",
     );
-    if (pubGet != 0) {
-      throw "Couldn't get dependencies in ${package.root}";
-    }
 
     final lockfile = package.lockfile;
     if (!lockfile.existsSync()) {

--- a/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
+++ b/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
@@ -42,8 +42,11 @@ class LockDependenciesCommand extends Command {
       }
     }
 
-    final pubGet = systemDart(['pub', 'get'],
-        workingDirectory: package.root, nothrow: true);
+    final pubGet = systemDart(
+      ['pub', 'get'],
+      workingDirectory: package.root,
+      nothrow: true,
+    );
     if (pubGet != 0) {
       throw "Couldn't get dependencies in ${package.root}";
     }

--- a/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
+++ b/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
@@ -45,7 +45,7 @@ class LockDependenciesCommand extends Command {
     systemDart(
       ['pub', 'get'],
       workingDirectory: package.root,
-      errorMessage: (_) => "Couldn't get dependencies in ${package.root}",
+      throwOnError: (_) => "Couldn't get dependencies in ${package.root}",
     );
 
     final lockfile = package.lockfile;

--- a/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
+++ b/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
@@ -1,5 +1,4 @@
 import 'package:sidekick_core/sidekick_core.dart';
-
 // ignore: implementation_imports, sk_sidekick is not a published package and already depends on sidekick_core from path
 import 'package:sidekick_core/src/version_checker.dart';
 import 'package:yaml/yaml.dart';
@@ -43,7 +42,8 @@ class LockDependenciesCommand extends Command {
       }
     }
 
-    final pubGet = systemDart(['pub', 'get'], workingDirectory: package.root);
+    final pubGet = systemDart(['pub', 'get'],
+        workingDirectory: package.root, nothrow: true);
     if (pubGet != 0) {
       throw "Couldn't get dependencies in ${package.root}";
     }

--- a/sk_sidekick/lib/src/commands/verify_publish_state_command.dart
+++ b/sk_sidekick/lib/src/commands/verify_publish_state_command.dart
@@ -55,14 +55,12 @@ class VerifyPublishStateCommand extends Command {
     );
 
     // dry-run publish should work without error
-    final code = dart(
+    dart(
       ['pub', 'publish', '--dry-run'],
       workingDirectory: package.root,
       nothrow: true,
+      errorMessage: (_) => 'Publish dry-run failed',
     );
-    if (code != 0) {
-      throw 'Publish dry-run failed';
-    }
   }
 }
 

--- a/sk_sidekick/lib/src/commands/verify_publish_state_command.dart
+++ b/sk_sidekick/lib/src/commands/verify_publish_state_command.dart
@@ -59,7 +59,7 @@ class VerifyPublishStateCommand extends Command {
       ['pub', 'publish', '--dry-run'],
       workingDirectory: package.root,
       nothrow: true,
-      throwOnError: (_) => 'Publish dry-run failed',
+      throwOnError: () => 'Publish dry-run failed',
     );
   }
 }

--- a/sk_sidekick/lib/src/commands/verify_publish_state_command.dart
+++ b/sk_sidekick/lib/src/commands/verify_publish_state_command.dart
@@ -59,7 +59,7 @@ class VerifyPublishStateCommand extends Command {
       ['pub', 'publish', '--dry-run'],
       workingDirectory: package.root,
       nothrow: true,
-      errorMessage: (_) => 'Publish dry-run failed',
+      throwOnError: (_) => 'Publish dry-run failed',
     );
   }
 }

--- a/sk_sidekick/lib/src/commands/verify_publish_state_command.dart
+++ b/sk_sidekick/lib/src/commands/verify_publish_state_command.dart
@@ -58,6 +58,7 @@ class VerifyPublishStateCommand extends Command {
     final code = dart(
       ['pub', 'publish', '--dry-run'],
       workingDirectory: package.root,
+      nothrow: true,
     );
     if (code != 0) {
       throw 'Publish dry-run failed';


### PR DESCRIPTION
Fixes #187 