### PR TITLE
Fix misleading update message

### DIFF
--- a/sidekick_core/lib/sidekick_core.dart
+++ b/sidekick_core/lib/sidekick_core.dart
@@ -323,9 +323,9 @@ class SidekickCommandRunner<T> extends CommandRunner<T> {
   /// CLI version listed in the pubspec at the path ['sidekick', 'cli_version']
   void _checkCliVersionIntegrity() {
     try {
-      final sidekickCoreVersion = VersionChecker.getMinimumVersionConstraint(
+      final sidekickCoreVersion = VersionChecker.getResolvedVersion(
         SidekickContext.sidekickPackage,
-        ['dependencies', 'sidekick_core'],
+        'sidekick_core',
       );
       if (sidekickCoreVersion == null) {
         // Couldn't parse sidekick_core version. Most likely because it uses

--- a/sidekick_core/lib/src/version_checker.dart
+++ b/sidekick_core/lib/src/version_checker.dart
@@ -154,10 +154,10 @@ abstract class VersionChecker {
   static Version? getResolvedVersion(DartPackage package, String dependency) {
     try {
       final resolvedVersion =
-      _readFromYaml(package.lockfile, ['packages', dependency, 'version']);
+          _readFromYaml(package.lockfile, ['packages', dependency, 'version']);
       return resolvedVersion.match(
-            () => null,
-            (t) => t != null ? Version.parse(t) : null,
+        () => null,
+        (t) => t != null ? Version.parse(t) : null,
       );
     } catch (e) {
       return null;

--- a/sidekick_core/lib/src/version_checker.dart
+++ b/sidekick_core/lib/src/version_checker.dart
@@ -152,12 +152,16 @@ abstract class VersionChecker {
   /// even if a local dependency doesn't explicitly specify a version in their
   /// pubspec.yaml, there always is an implicit version of 0.0.0
   static Version? getResolvedVersion(DartPackage package, String dependency) {
-    final resolvedVersion =
-        _readFromYaml(package.lockfile, ['packages', dependency, 'version']);
-    return resolvedVersion.match(
-      () => null,
-      (t) => t != null ? Version.parse(t) : null,
-    );
+    try {
+      final resolvedVersion =
+      _readFromYaml(package.lockfile, ['packages', dependency, 'version']);
+      return resolvedVersion.match(
+            () => null,
+            (t) => t != null ? Version.parse(t) : null,
+      );
+    } catch (e) {
+      return null;
+    }
   }
 
   /// Returns the latest version of [dependency] available on pub.dev

--- a/sidekick_core/test/sidekick_command_runner_test.dart
+++ b/sidekick_core/test/sidekick_command_runner_test.dart
@@ -14,7 +14,7 @@ void main() {
   });
 
   final expectedCliVersionIntegrityWarnings = [
-    contains('sidekick_core:0.0.2'),
+    contains('sidekick_core:0.0.5'),
     contains('sidekick.cli_version 0.0.1'),
     contains('dash sidekick update'),
   ];
@@ -42,8 +42,9 @@ void main() {
           },
         );
       },
-      sidekickCoreVersion: "0.0.2",
+      sidekickCoreVersion: "^0.0.2",
       sidekickCliVersion: "0.0.1",
+      lockedSidekickCoreVersion: "0.0.5", // might be higher
     );
   });
 
@@ -60,12 +61,13 @@ void main() {
 
             await runner.run(['-h']);
 
-            expect(fakeStderr.lines.isEmpty, isTrue);
+            expect(fakeStderr.lines.join('\n'), '');
           },
         );
       },
       sidekickCoreVersion: "0.0.1",
       sidekickCliVersion: "0.0.1",
+      lockedSidekickCoreVersion: "0.0.1",
     );
   });
 
@@ -90,8 +92,9 @@ void main() {
           },
         );
       },
-      sidekickCoreVersion: "0.0.2",
+      sidekickCoreVersion: "0.0.5",
       sidekickCliVersion: "0.0.1",
+      lockedSidekickCoreVersion: "0.0.5",
     );
   });
 
@@ -111,8 +114,9 @@ void main() {
           },
         );
       },
-      sidekickCoreVersion: "0.0.2",
+      sidekickCoreVersion: "0.0.5",
       sidekickCliVersion: "0.0.1",
+      lockedSidekickCoreVersion: "0.0.5",
     );
   });
 
@@ -137,8 +141,9 @@ void main() {
           },
         );
       },
-      sidekickCoreVersion: "0.0.2",
+      sidekickCoreVersion: "0.0.5",
       sidekickCliVersion: "0.0.1",
+      lockedSidekickCoreVersion: "0.0.5",
     );
   });
 }

--- a/sidekick_test/lib/src/local_testing.dart
+++ b/sidekick_test/lib/src/local_testing.dart
@@ -47,12 +47,14 @@ final bool analyzeGeneratedCode = env['SIDEKICK_ANALYZE'] == 'true';
 ///   override to use the local sidekick_core dependency
 /// - [sidekickCoreVersion] the dependency of sidekick_core in the pubspec.
 ///   Only written to pubspec if value is not null.
+/// - [lockedSidekickCoreVersion] the used version in pubspec.lock
 /// - [sidekickCliVersion] sidekick: cli_version: <sidekickCliVersion> in the
 ///   pubspec. Only written to pubspec if value is not null.
 R insideFakeProjectWithSidekick<R>(
   R Function(Directory projectRoot) callback, {
   bool overrideSidekickCoreWithLocalDependency = false,
   String? sidekickCoreVersion,
+  String? lockedSidekickCoreVersion,
   String? sidekickCliVersion,
   bool insideGitRepo = false,
 }) {
@@ -93,6 +95,14 @@ ${sidekickCliVersion == null ? '' : '''
 sidekick:
   cli_version: $sidekickCliVersion
 '''}
+''');
+  fakeSidekickDir.file('pubspec.lock')
+    ..createSync()
+    ..writeAsStringSync('''
+packages:
+  sidekick_core:
+    dependency: "direct main"
+    version: "${lockedSidekickCoreVersion ?? '0.0.0'}"
 ''');
 
   final fakeSidekickLibDir = fakeSidekickDir.directory('lib')..createSync();

--- a/sidekick_test/lib/src/local_testing.dart
+++ b/sidekick_test/lib/src/local_testing.dart
@@ -102,6 +102,10 @@ sidekick:
 packages:
   sidekick_core:
     dependency: "direct main"
+    source: hosted
+    description:
+      name: sidekick_core
+      url: "https://pub.dev"
     version: "${lockedSidekickCoreVersion ?? '0.0.0'}"
 ''');
 


### PR DESCRIPTION
The cli was showing this false positive error message 

```bash
❯ ./da
A sidekick CLI to equip Dart/Flutter projects with custom tasks

Available commands:
  analyze    Dart analyzes the whole project
  clean      Cleans the project
  dart       Calls dart
  deps       Gets dependencies for all packages
  sidekick   Manages the sidekick CLI

Run "da help <command>" for more information about a command.
Dependency sidekick_core:0.10.0 doesn't match sidekick.cli_version 0.15.1 in your pubspec.yaml.
This is a signal that sidekick_core was updated manually without calling 'sidekick update'. Some features in your CLI might not work as expected.

Please run da sidekick update to execute the missing migrations.
```

It is caused by those `sidekick_core` version definitions:

```yaml
dependencies:
  sidekick_core: '>=0.10.0 <1.0.0'

sidekick:
  cli_version: 0.15.1
```

Before this change, the version checker was comparing `dependencies.sidekick_core.lowerBound` to `sidekick.cli_version`. Obviously `0.10.0 != 0.15.1`. The mistake is that `0.15.1` is actually used and defined in `pubspec.lock`.

This fix now checks `pubspec.lock` for the resolved version.

