### PR TITLE
Lock dependencies should not ignore lower bound constraints

### DIFF
--- a/sidekick/pubspec.lock
+++ b/sidekick/pubspec.lock
@@ -517,10 +517,10 @@ packages:
     dependency: "direct main"
     description:
       name: sidekick_core
-      sha256: "07c436c858c3782d380b62c3ebfdc9102479c8e9afc6a64d714b9734481dfb7e"
+      sha256: eb99ba0ab27123cb8c309f358353d55fee741106e741c18b1220e81f757e8b9d
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   sidekick_test:
     dependency: "direct dev"
     description:

--- a/sidekick/pubspec.yaml
+++ b/sidekick/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   path: ^1.8.0
   process: ^4.2.4
   recase: ^4.0.0
-  sidekick_core: ^1.0.0
+  sidekick_core: ^1.0.2
 
 dev_dependencies:
   lint: ^1.5.0

--- a/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
+++ b/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
@@ -45,7 +45,7 @@ class LockDependenciesCommand extends Command {
     }
 
     systemDart(
-      ['pub', 'upgrade'],
+      ['pub', 'get'],
       workingDirectory: package.root,
       throwOnError: () => "Couldn't update dependencies in ${package.root}",
     );

--- a/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
+++ b/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
@@ -1,4 +1,6 @@
-import 'package:sidekick_core/sidekick_core.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:sidekick_core/sidekick_core.dart' hide PubSpec, version;
+
 // ignore: implementation_imports, sk_sidekick is not a published package and already depends on sidekick_core from path
 import 'package:sidekick_core/src/version_checker.dart';
 import 'package:yaml/yaml.dart';
@@ -43,9 +45,9 @@ class LockDependenciesCommand extends Command {
     }
 
     systemDart(
-      ['pub', 'get'],
+      ['pub', 'upgrade'],
       workingDirectory: package.root,
-      throwOnError: () => "Couldn't get dependencies in ${package.root}",
+      throwOnError: () => "Couldn't update dependencies in ${package.root}",
     );
 
     final lockfile = package.lockfile;
@@ -53,44 +55,81 @@ class LockDependenciesCommand extends Command {
       throw "Lockfile doesn't exist in ${package.root}";
     }
 
-    final packages =
+    final constrainedVersions = (loadYaml(package.pubspec.readAsStringSync())
+        as YamlMap)['dependencies'] as YamlMap;
+    final lockedVersions =
         // ignore: avoid_dynamic_calls
         loadYaml(lockfile.readAsStringSync())['packages'] as YamlMap;
 
-    final Map<String, String> directDependencies = {};
-    final Map<String, String> transitiveDependencies = {};
-    for (final package in packages.entries) {
+    final Map<String, VersionRange> directDependencies = {};
+    final Map<String, VersionRange> transitiveDependencies = {};
+    for (final package in lockedVersions.entries) {
       final value = package.value as YamlMap;
       final type = value['dependency'];
       final packageName = package.key as String;
-      final version = value['version'] as String;
+      final Version latestVersion = Version.parse(value['version'] as String);
+      final VersionRange? constraints = () {
+        try {
+          final rawConstraints = constrainedVersions[packageName] as String?;
+          return VersionConstraint.parse(rawConstraints!) as VersionRange;
+        } catch (e) {
+          return null;
+        }
+      }();
 
       if (type != 'direct dev' && value['source'] != 'hosted') {
         throw "Can only handle dependencies from hosted sources, but $packageName violates this.";
       }
 
+      final VersionRange range;
+      if (constraints == null) {
+        // Not a direct dependency,
+        final lowerBound = latestVersion.major > 0
+            ? Version(latestVersion.major, 0, 0)
+            : Version(0, latestVersion.minor, 0);
+        range = VersionRange(
+          min: lowerBound,
+          max: latestVersion,
+          includeMax: true,
+          includeMin: true,
+        );
+      } else {
+        // Direct dependency with constraints
+        // Combines latest version from pub (lock file) with the version
+        // constraints from the pubspec.yaml file
+        range = VersionRange(
+          min: constraints.min,
+          max: latestVersion,
+          includeMax: true,
+          includeMin: true,
+        );
+      }
+      assert(range.allows(latestVersion),
+          'Latest version $latestVersion is not allowed by $range');
+
       switch (type) {
         case 'transitive':
-          transitiveDependencies[packageName] = version;
+          transitiveDependencies[packageName] = range;
           break;
         case 'direct main':
-          directDependencies[packageName] = version;
+          directDependencies[packageName] = range;
           break;
         // case 'direct dev' is irrelevant
       }
     }
 
     final pinnedDirectDependencies = directDependencies
-        .mapEntries((e) => "  ${e.key}: ${e.value.lockedConstraintRange}")
+        .mapEntries((e) => "  ${e.key}: '${e.value}'")
         .sorted();
     final pinnedTransitiveDependencies = transitiveDependencies
-        .mapEntries((e) => "  ${e.key}: ${e.value.lockedConstraintRange}")
+        .mapEntries((e) => "  ${e.key}: '${e.value}'")
         .sorted();
 
     final lockedDependencies = [
       'dependencies:',
       '  # direct dependencies',
       ...pinnedDirectDependencies,
+      '',
       '  # transitive dependencies',
       ...pinnedTransitiveDependencies,
     ].join('\n');
@@ -107,16 +146,5 @@ class LockDependenciesCommand extends Command {
     package.pubspec.replaceFirst(currentDependenciesBlock, lockedDependencies);
 
     print(green('Locked dependencies of ${package.name}!'));
-  }
-}
-
-extension on String {
-  String get lockedConstraintRange {
-    final version = Version.parse(this);
-    final lowerBound = version.major > 0
-        ? Version(version.major, 0, 0)
-        : Version(0, version.minor, 0);
-
-    return version == lowerBound ? '$version' : "'>=$lowerBound <=$version'";
   }
 }

--- a/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
+++ b/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
@@ -104,8 +104,10 @@ class LockDependenciesCommand extends Command {
           includeMin: true,
         );
       }
-      assert(range.allows(latestVersion),
-          'Latest version $latestVersion is not allowed by $range');
+      assert(
+        range.allows(latestVersion),
+        'Latest version $latestVersion is not allowed by $range',
+      );
 
       switch (type) {
         case 'transitive':


### PR DESCRIPTION
I tried to force `sidekick_core: ^1.0.2` but `sk lock-dependencies` always resolved to `sidekick_core: '>=1.0.0 <=1.0.2`. It did not read the constraints from `pubspec.yaml`.

Now it constrains the version correctly.
<img width="241" alt="Screen-Shot-2023-01-25-16-22-03 39" src="https://user-images.githubusercontent.com/1096485/214603390-5f37a159-7890-4405-afbe-c391f403aee5.png">

<img width="303" alt="Screen-Shot-2023-01-25-16-21-58 62" src="https://user-images.githubusercontent.com/1096485/214603424-2ed4bf94-243c-48d3-9a02-ce1efde084ac.png">
