### PR TITLE
Show success message after init

### DIFF
--- a/sidekick/lib/src/commands/init_command.dart
+++ b/sidekick/lib/src/commands/init_command.dart
@@ -218,6 +218,9 @@ class InitCommand extends Command {
       ['format', cliPackage.path],
       progress: dcli.Progress.printStdErr(),
     );
+    print(
+      green('Successfully generated ${cliName}_sidekick 🎉'),
+    );
   }
 }
 

--- a/sidekick/test/init_test.dart
+++ b/sidekick/test/init_test.dart
@@ -67,6 +67,12 @@ void main() {
               ),
           isTrue,
         );
+        expect(
+          process.stdout,
+          isNot(
+            contains('Successfully generated dashi_sidekick 🎉'),
+          ),
+        );
       },
       timeout: const Timeout(Duration(minutes: 5)),
     );
@@ -98,6 +104,12 @@ void main() {
                 'CLI package directory ${tempDir.path} is not within or equal to ${projectRoot.path}',
               ),
           isTrue,
+        );
+        expect(
+          process.stdout,
+          isNot(
+            contains('Successfully generated dashi_sidekick 🎉'),
+          ),
         );
       },
       timeout: const Timeout(Duration(minutes: 5)),
@@ -132,6 +144,12 @@ void main() {
               ),
           isTrue,
         );
+        expect(
+          process.stdout,
+          isNot(
+            contains('Successfully generated dashi_sidekick 🎉'),
+          ),
+        );
       },
       timeout: const Timeout(Duration(minutes: 5)),
     );
@@ -164,6 +182,12 @@ void main() {
               ),
           isTrue,
         );
+        expect(
+          process.stdout,
+          isNot(
+            contains('Successfully generated dashi_sidekick 🎉'),
+          ),
+        );
       },
       timeout: const Timeout(Duration(minutes: 5)),
     );
@@ -180,6 +204,12 @@ void main() {
         expect(
           await process.stderr.rest.contains(invalidCliNameErrorMessage),
           isTrue,
+        );
+        expect(
+          process.stdout,
+          isNot(
+            contains('Successfully generated dashi_sidekick 🎉'),
+          ),
         );
       },
     );
@@ -200,6 +230,12 @@ void main() {
             'The CLI name rm is already taken by an executable on your system see [/bin/rm]',
           ),
         );
+        expect(
+          process.stdout,
+          isNot(
+            contains('Successfully generated dashi_sidekick 🎉'),
+          ),
+        );
       },
     );
   });
@@ -214,6 +250,12 @@ void main() {
         final process = await cachedGlobalSidekickCli.run(
           ['init', '-n', 'dashi'],
           workingDirectory: projectRoot,
+        );
+        final stdout = await process.stdoutStream().join('\n');
+
+        expect(
+          stdout,
+          contains('Successfully generated dashi_sidekick 🎉'),
         );
         await process.shouldExit(0);
         final entrypoint = File("${projectRoot.path}/dashi");
@@ -279,6 +321,12 @@ void main() {
           ],
           workingDirectory: Directory.current,
         );
+        final stdout = await process.stdoutStream().join('\n');
+
+        expect(
+          stdout,
+          contains('Successfully generated dashi_sidekick 🎉'),
+        );
         printOnFailure(await process.stdoutStream().join('\n'));
         printOnFailure(await process.stderrStream().join('\n'));
         await process.shouldExit(0);
@@ -343,6 +391,13 @@ void main() {
           process.stdout,
           emitsThrough('Generating dashi_sidekick'),
         );
+        final stdout = await process.stdoutStream().join('\n');
+
+        expect(
+          stdout,
+          contains('Successfully generated dashi_sidekick 🎉'),
+        );
+
         printOnFailure(await process.stdoutStream().join('\n'));
         printOnFailure(await process.stderrStream().join('\n'));
         await process.shouldExit(0);


### PR DESCRIPTION
Showing a success message after we successfully run `sidekick init`.
Resolving #36 