### PR TITLE
Update vault readme

### DIFF
--- a/sidekick_vault/README.md
+++ b/sidekick_vault/README.md
@@ -2,6 +2,14 @@
 
 A place to store project secrets within a git repository, encrypted with GPG
 
+## Install the plugin
+
+Installing the vault is quite easy. Just run the following command in your project:
+
+```bash
+<<your_cli>> sidekick plugins install sidekick_vault
+```
+
 ## Manage vault with VaultCommand
 
 ### Add file to vault

--- a/sidekick_vault/README.md
+++ b/sidekick_vault/README.md
@@ -73,10 +73,10 @@ A place to store project secrets within a git repository, encrypted with GPG
 ```
 
 ```bash
-<cli-name> vault encrypt --passpharse="****" --vault-location="secret.txt.gpg" path/to/secret.txt
+<cli-name> vault encrypt --passphrase="****" --vault-location="secret.txt.gpg" path/to/secret.txt
 ```
 
-The `passpharse` is optional.
+The `passphrase` is optional.
 It will be retrieved from the environment variables or asked via `stdin`.
 
 The file will be saved at `vault-location` (optional) inside the vault directory.
@@ -89,10 +89,10 @@ The filename (`secret.txt`) will be used as fallback.
 ```
 
 ```bash
-<cli-name> vault decrypt --passpharse="****" --output="write/to/decrypted.txt" secret.txt.gpg';
+<cli-name> vault decrypt --passphrase="****" --output="write/to/decrypted.txt" secret.txt.gpg';
 ```
 
-The `passpharse` is optional.
+The `passphrase` is optional.
 It will be retrieved from the environment variables or asked via `stdin`.
 
 `output` is optional.

--- a/sidekick_vault/README.md
+++ b/sidekick_vault/README.md
@@ -2,68 +2,6 @@
 
 A place to store project secrets within a git repository, encrypted with GPG
 
-# Create the Vault
-
-1. Create a `vault` directory in your project
-
-2. Place a `README.md` in `vault`
-
-    ````markdown
-    # Vault
-    
-    This vault contains gpg encrypted passwords and certificates.
-    
-    To get the password to the vault ask one of the administrators.
-    This password is available on CI as environment variable `FLT_VAULT_PASSPHRASE`
-   
-   ## List existing secrets
-
-   ```
-   <cli-name> vault list
-   ```
-    
-    ## Encrypt secrets
-    
-    ```
-    <cli-name> vault encrypt file.csv
-    ```
-    
-    ## Decrypt secrets
-    
-    ```
-    <cli-name> vault decrypt file.csv.gpg
-    ```
-    ````
-
-3. Place a `.gitignore` in `vault`
-
-    ```gitignore
-    # Ignore everything in this folder which isn't gpg encrypted
-    *
-    !*.gpg
-    
-    # Exceptions
-    !README.md
-    !.gitignore
-    ```
-
-4. Register the `VaultCommand` in your sidekick CLI
-
-   ```dart
-   import 'package:sidekick_vault/sidekick_vault.dart';
-   
-   final vault = SidekickVault(
-     location: FlgProject.root.directory('vault'),
-     environmentVariableName: 'FLG_VAULT_PASSPHRASE',
-   );
-   
-   final runner = FlgCommandRunner()
-       ..addCommand(FlutterCommand())
-       ..addCommand(InstallGlobalCommand())
-       // more commands
-       ..addCommand(VaultCommand(vault: vault)); // <-- Add the VaultCommand
-   ```
-
 ## Manage vault with VaultCommand
 
 ### Add file to vault

--- a/sidekick_vault/lib/src/commands/vault_command.dart
+++ b/sidekick_vault/lib/src/commands/vault_command.dart
@@ -46,7 +46,7 @@ class _EncryptCommand extends Command {
   @override
   String? get usageFooter => '\n${green('Example usage:')}\n'
       '> ${SidekickContext.cliName} vault encrypt secret.txt.gpg\n'
-      '> ${SidekickContext.cliName} vault encrypt --passpharse="****" --vault-location="secret.txt.gpg" path/to/secret.txt';
+      '> ${SidekickContext.cliName} vault encrypt --passphrase="****" --vault-location="secret.txt.gpg" path/to/secret.txt';
 
   final SidekickVault vault;
 
@@ -93,7 +93,7 @@ class _DecryptCommand extends Command {
   @override
   String? get usageFooter => '\n${green('Example usage:')}\n'
       '> ${SidekickContext.cliName} vault decrypt secret.txt.gpg\n'
-      '> ${SidekickContext.cliName} vault decrypt --passpharse="****" --output="write/to/decrypted.txt" secret.txt.gpg';
+      '> ${SidekickContext.cliName} vault decrypt --passphrase="****" --output="write/to/decrypted.txt" secret.txt.gpg';
 
   final SidekickVault vault;
 


### PR DESCRIPTION
Updated the vault readme to be up-to date.

- Fixed typo `passpharse` to `passphrase`
- Removed out-dated create vault section
- Add Install section

Addressing Issue #217 