### PR TITLE
Allow major versions when upgrading

### DIFF
--- a/sidekick_core/lib/src/template/install.sh.template.dart
+++ b/sidekick_core/lib/src/template/install.sh.template.dart
@@ -63,17 +63,25 @@ cd "${CLI_PACKAGE_DIR}" || exit
     deleteLine
     echoerr "✔ Compiling sidekick cli"
   else
-    echoerr "Compilation failed. Trying dart pub upgrade"
+    echoerr "Compilation failed. Trying dart pub upgrade (Retry 1)"
     LOCK_FILE=$(cat pubspec.lock)
-    runSilent "${DART}" pub upgrade --major-versions
+    runSilent "${DART}" pub upgrade
     echoerr "- Compiling sidekick cli with updated dependencies"
     if runSilent "${DART}" compile exe -o "${EXE}" bin/main.dart; then
       deleteLine
       echoerr "✔ Compiling sidekick cli with updated dependencies"
     else
-      echoerr "Compilation with updated dependencies failed, too. Restoring pubspec.lock"
-      echo "$LOCK_FILE" > pubspec.lock
-      exit 1
+      echoerr "Compilation failed again. Trying dart pub upgrade --major-versions (Retry 2)"
+      runSilent "${DART}" pub upgrade --major-versions
+      echoerr "- Compiling sidekick cli with major updated dependencies"
+      if runSilent "${DART}" compile exe -o "${EXE}" bin/main.dart; then
+        deleteLine
+        echoerr "✔ Compiling sidekick cli with major updated dependencies"
+      else
+        echoerr "Compilation with updated and major updated dependencies failed. Restoring pubspec.lock"
+        echo "$LOCK_FILE" > pubspec.lock
+        exit 1
+      fi
     fi
   fi
   echoerr "🎉Success!\n"

--- a/sidekick_core/lib/src/template/install.sh.template.dart
+++ b/sidekick_core/lib/src/template/install.sh.template.dart
@@ -65,7 +65,7 @@ cd "${CLI_PACKAGE_DIR}" || exit
   else
     echoerr "Compilation failed. Trying dart pub upgrade"
     LOCK_FILE=$(cat pubspec.lock)
-    runSilent "${DART}" pub upgrade
+    runSilent "${DART}" pub upgrade --major-versions
     echoerr "- Compiling sidekick cli with updated dependencies"
     if runSilent "${DART}" compile exe -o "${EXE}" bin/main.dart; then
       deleteLine


### PR DESCRIPTION
Add a third compilation stage that updates major versions. This is especially useful for `0.X` releases.

This should also be backported to `sidekick_core: 0.X` 