### PR TITLE
Prepare InstallPluginCommand for use with Dart 2.19 (default pub hosted url changed)

### DIFF
--- a/sidekick_core/lib/src/dart_runtime.dart
+++ b/sidekick_core/lib/src/dart_runtime.dart
@@ -8,7 +8,7 @@ final sidekickDartRuntime =
 
 /// Version and channel of [sidekickDartRuntime]
 final sidekickDartVersion =
-    VersionChecker.getDartVersion(sidekickDartRuntime.dartSdkPath.path);
+    VersionChecker.getDartVersion(sidekickDartRuntime._dartExecutable.path);
 
 /// The bundled Dart runtime of a sidekick CLI
 class SidekickDartRuntime {
@@ -49,22 +49,23 @@ class SidekickDartRuntime {
     dcli.Progress? progress,
     bool nothrow = false,
   }) {
-    final binDir = dartSdkPath.directory('bin');
-    final dart = () {
-      if (Platform.isWindows) {
-        return binDir.file('dart.exe');
-      } else {
-        return binDir.file('dart');
-      }
-    }();
-
     dcli.startFromArgs(
-      dart.path,
+      _dartExecutable.path,
       args,
       workingDirectory: workingDirectory?.path,
       progress: progress,
       nothrow: nothrow,
       terminal: progress == null,
     );
+  }
+
+  File get _dartExecutable {
+    final binDir = dartSdkPath.directory('bin');
+
+    if (Platform.isWindows) {
+      return binDir.file('dart.exe');
+    } else {
+      return binDir.file('dart');
+    }
   }
 }

--- a/sidekick_core/lib/src/dart_runtime.dart
+++ b/sidekick_core/lib/src/dart_runtime.dart
@@ -1,9 +1,14 @@
 import 'package:dcli/dcli.dart' as dcli;
 import 'package:sidekick_core/sidekick_core.dart';
+import 'package:sidekick_core/src/version_checker.dart';
 
 /// default Dart runtime which is currently used to execute this sidekick CLI
 final sidekickDartRuntime =
     SidekickDartRuntime(SidekickContext.sidekickPackage.root);
+
+/// Version and channel of [sidekickDartRuntime]
+final sidekickDartVersion =
+    VersionChecker.getDartVersion(sidekickDartRuntime.dartSdkPath.path);
 
 /// The bundled Dart runtime of a sidekick CLI
 class SidekickDartRuntime {

--- a/sidekick_core/test/version_checker_test.dart
+++ b/sidekick_core/test/version_checker_test.dart
@@ -1,5 +1,6 @@
 import 'package:sidekick_core/sidekick_core.dart';
 import 'package:sidekick_core/src/version_checker.dart';
+import 'package:sidekick_test/sidekick_test.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -290,6 +291,26 @@ packages:
 
       final actual = VersionChecker.getResolvedVersion(package, 'foo');
       expect(actual, Version(42, 0, 0));
+    });
+  });
+
+  group('getDartVersion', () {
+    test('parses version and channel from version info string', () {
+      const versionInfostring =
+          'Dart SDK version: 2.18.4 (stable) (Tue Nov 1 15:15:07 2022 +0000) on "macos_arm64"';
+      final fakeDart = fakePrintingDartSdk(versionInfostring).file('bin/dart');
+
+      final expected =
+          SdkVersion(version: Version(2, 18, 4), channel: 'stable');
+      final actual = VersionChecker.getDartVersion(fakeDart.path);
+      expect(actual, expected);
+    });
+
+    test('does not crash with real Dart SDK', () {
+      expect(
+        () => VersionChecker.getDartVersion(systemDartExecutable()!),
+        returnsNormally,
+      );
     });
   });
 }

--- a/sidekick_test/lib/src/fake_sdk.dart
+++ b/sidekick_test/lib/src/fake_sdk.dart
@@ -79,3 +79,20 @@ exit 1''');
 
   return temp;
 }
+
+/// Creates a fake Dart SDK with a `dart` executable that prints the given text
+Directory fakePrintingDartSdk(String text) {
+  final temp = Directory.systemTemp.createTempSync('fake_dart');
+  addTearDown(() => temp.deleteSync(recursive: true));
+
+  final textFile = temp.file('text')..writeAsStringSync(text);
+  final exe = temp.file('bin/dart')
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+#!/bin/bash
+cat ${textFile.path}
+''');
+  dcli.run('chmod 755 ${exe.path}');
+
+  return temp;
+}


### PR DESCRIPTION
In Dart 2.19, the default pub-cache folder changed from `.pub-cache/pub.dartlang.org` to `.pub-cache/pub.dev`. Without this change, InstallPluginCommand would break because we would be looking for the downloaded plugin in the wrong cache folder.