### PR TITLE
FormatCommand.formatGenerated allows ignoring generated files (.g.dart)

### DIFF
--- a/sidekick_core/lib/src/commands/format_command.dart
+++ b/sidekick_core/lib/src/commands/format_command.dart
@@ -49,7 +49,9 @@ class FormatCommand extends Command {
   /// specified in pubspec.yaml.
   final int defaultLineLength;
 
-  /// When true, generated files (`.g.dart`, or `.freezed.dart`) formatted as well.
+  /// Set to false to *not* format generated files (`.g.dart`, or `.freezed.dart`)
+  ///
+  /// Defaults to `true`
   final bool formatGenerated;
 
   FormatCommand({

--- a/sidekick_core/test/format_command_test.dart
+++ b/sidekick_core/test/format_command_test.dart
@@ -324,9 +324,12 @@ name: dashi
 ''',
           mainContent: _dartFile140,
         );
-        final hiddenFolderFile = dir.file('file.g.dart')
+        final gFile = dir.file('file.g.dart')..createSync(recursive: true);
+        gFile.writeAsStringSync(_dartFile140);
+
+        final freezedFile = dir.file('file.freezed.dart')
           ..createSync(recursive: true);
-        hiddenFolderFile.writeAsStringSync(_dartFile140);
+        freezedFile.writeAsStringSync(_dartFile140);
 
         final runner = initializeSidekick(dartSdkPath: systemDartSdkPath());
         runner.addCommand(FormatCommand(formatGenerated: false));
@@ -334,6 +337,7 @@ name: dashi
 
         expect(dir.file('lib/main.dart').readAsStringSync(), _dartFile80);
         expect(dir.file('file.g.dart').readAsStringSync(), _dartFile140);
+        expect(dir.file('file.freezed.dart').readAsStringSync(), _dartFile140);
       });
     });
 
@@ -346,9 +350,12 @@ name: dashi
 ''',
           mainContent: _dartFile140,
         );
-        final hiddenFolderFile = dir.file('file.g.dart')
+        final gFile = dir.file('file.g.dart')..createSync(recursive: true);
+        gFile.writeAsStringSync(_dartFile140);
+
+        final freezedFile = dir.file('file.freezed.dart')
           ..createSync(recursive: true);
-        hiddenFolderFile.writeAsStringSync(_dartFile140);
+        freezedFile.writeAsStringSync(_dartFile140);
 
         final runner = initializeSidekick(dartSdkPath: systemDartSdkPath());
         runner.addCommand(FormatCommand());
@@ -356,6 +363,7 @@ name: dashi
 
         expect(dir.file('lib/main.dart').readAsStringSync(), _dartFile80);
         expect(dir.file('file.g.dart').readAsStringSync(), _dartFile80);
+        expect(dir.file('file.freezed.dart').readAsStringSync(), _dartFile80);
       });
     });
 

--- a/sidekick_core/test/format_command_test.dart
+++ b/sidekick_core/test/format_command_test.dart
@@ -315,6 +315,50 @@ name: dashi
       });
     });
 
+    test('formatGenerated = false', () async {
+      await insideFakeProjectWithSidekick((dir) async {
+        setupProject(
+          dir,
+          pubspecContent: '''
+name: dashi
+''',
+          mainContent: _dartFile140,
+        );
+        final hiddenFolderFile = dir.file('file.g.dart')
+          ..createSync(recursive: true);
+        hiddenFolderFile.writeAsStringSync(_dartFile140);
+
+        final runner = initializeSidekick(dartSdkPath: systemDartSdkPath());
+        runner.addCommand(FormatCommand(formatGenerated: false));
+        await runner.run(['format']);
+
+        expect(dir.file('lib/main.dart').readAsStringSync(), _dartFile80);
+        expect(dir.file('file.g.dart').readAsStringSync(), _dartFile140);
+      });
+    });
+
+    test('default: formatGenerated = true', () async {
+      await insideFakeProjectWithSidekick((dir) async {
+        setupProject(
+          dir,
+          pubspecContent: '''
+name: dashi
+''',
+          mainContent: _dartFile140,
+        );
+        final hiddenFolderFile = dir.file('file.g.dart')
+          ..createSync(recursive: true);
+        hiddenFolderFile.writeAsStringSync(_dartFile140);
+
+        final runner = initializeSidekick(dartSdkPath: systemDartSdkPath());
+        runner.addCommand(FormatCommand());
+        await runner.run(['format']);
+
+        expect(dir.file('lib/main.dart').readAsStringSync(), _dartFile80);
+        expect(dir.file('file.g.dart').readAsStringSync(), _dartFile80);
+      });
+    });
+
     test('--verify throws, but does not format', () async {
       await insideFakeProjectWithSidekick((dir) async {
         dir.file('some.dart').writeAsStringSync(_dartFile140);


### PR DESCRIPTION
```dart
// ignores *.g.dart and *.freezed.dart files
runner.addCommand(FormatCommand(formatGenerated: false));
```