### PR TITLE
Fix `FormatCommand` `--verify` exception message, print unformatted files

### DIFF
--- a/sidekick_core/lib/src/commands/format_command.dart
+++ b/sidekick_core/lib/src/commands/format_command.dart
@@ -131,7 +131,7 @@ class FormatCommand extends Command {
     if (verify && foundFormatError) {
       throw DartFileFormatException(
         'Dart files are not correctly formatted. '
-        'Run "${SidekickContext.cliName} sidekick format" to format the code.',
+        'Run "${SidekickContext.cliName} format" to format the code.',
       );
     }
   }
@@ -227,4 +227,7 @@ class DartFileFormatException implements Exception {
   final String message;
 
   DartFileFormatException(this.message);
+
+  @override
+  String toString() => message;
 }

--- a/sidekick_core/lib/src/commands/format_command.dart
+++ b/sidekick_core/lib/src/commands/format_command.dart
@@ -162,6 +162,9 @@ class FormatCommand extends Command {
         if (verify) '--output=none',
       ],
       nothrow: verify,
+      // Lines like `Changed x.dart`, `Formatted x files (y changed) in z seconds`
+      // should only be printed when the change is actually written to the files (when verify is false)
+      progress: verify ? Progress.devNull() : Progress.print(),
     );
     if (exitCode != 0) {
       foundFormatError = true;

--- a/sidekick_core/test/format_command_test.dart
+++ b/sidekick_core/test/format_command_test.dart
@@ -324,7 +324,13 @@ name: dashi
         runner.addCommand(FormatCommand());
         expectLater(
           () => runner.run(['format', '--verify']),
-          throwsA(isA<DartFileFormatException>()),
+          throwsA(
+            isA<DartFileFormatException>().having(
+              (p0) => p0.toString(),
+              'String representation',
+              'Dart files are not correctly formatted. Run "dash format" to format the code.',
+            ),
+          ),
         );
 
         expect(dir.file('some.dart').readAsStringSync(), _dartFile140);


### PR DESCRIPTION
Fixes #222 