### PR TITLE
[Dart 3] Update sidekick_core & CI

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: dart:2.18.6
+      image: dart:3.0.0
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         # Always keep support to at least 2 stable versions
-        version: [ "2.14", "2.15", "2.16", "2.17", "2.18", "latest" ]
+        version: [ "2.19", "3.0", "latest" ]
 
     container:
       image: dart:${{ matrix.version }}
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         # Always keep support to at least 2 stable versions
-        version: ["2.14", "2.15", "2.16", "2.17", "2.18", "latest"]
+        version: [ "2.19", "3.0", "latest" ]
 
     container:
       image: dart:${{ matrix.version }}
@@ -57,7 +57,7 @@ jobs:
         run: cd sidekick && dart test test/test_runner.dart
         env:
           SIDEKICK_PUB_DEPS: "true"
-          SIDEKICK_ANALYZE: "${{ matrix.version == '2.18' }}"
+          SIDEKICK_ANALYZE: "${{ matrix.version == '3.0' }}"
       - name: Run latest sidekick from pub
         run: |
           set -o errexit

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: dart:2.18.6
+      image: dart:3.0.0
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: dart:2.18.6
+      image: dart:3.0.0
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: dart:2.18.6
+      image: dart:2.19.0
 
     steps:
       - uses: actions/checkout@v1
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: dart:2.18.6
+      image: dart:2.19.0
 
     steps:
       - uses: actions/checkout@v1

--- a/sidekick/lib/src/commands/init_command.dart
+++ b/sidekick/lib/src/commands/init_command.dart
@@ -4,7 +4,7 @@ import 'package:sidekick/src/util/dcli_ask_validators.dart';
 import 'package:sidekick/src/util/directory_extension.dart';
 import 'package:sidekick/src/util/name_suggester.dart';
 import 'package:sidekick_core/sidekick_core.dart'
-    hide mainProject, repository, cliName, cliNameOrNull, entryWorkingDirectory;
+    hide cliName, cliNameOrNull, entryWorkingDirectory, mainProject, repository;
 import 'package:sidekick_core/sidekick_core.dart' as core;
 
 class InitCommand extends Command {

--- a/sidekick/pubspec.lock
+++ b/sidekick/pubspec.lock
@@ -524,9 +524,11 @@ packages:
   sidekick_test:
     dependency: "direct dev"
     description:
-      path: "../sidekick_test"
-      relative: true
-    source: path
+      path: sidekick_test
+      ref: "sidekick_core-v1.2.0"
+      resolved-ref: "389474ba9630aae17b225f0b9a2957906ad94ee9"
+      url: "https://github.com/phntmxyz/sidekick.git"
+    source: git
     version: "1.0.0"
   source_map_stack_trace:
     dependency: transitive

--- a/sidekick/pubspec.lock
+++ b/sidekick/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0c80aeab9bc807ab10022cd3b2f4cf2ecdf231949dc1ddd9442406a003f19201"
+      sha256: "405666cd3cf0ee0a48d21ec67e65406aad2c726d9fa58840d3375e7bdcd32a07"
       url: "https://pub.dev"
     source: hosted
-    version: "52.0.0"
+    version: "60.0.0"
   acronym:
     dependency: "direct main"
     description:
@@ -21,34 +21,34 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: cd8ee83568a77f3ae6b913a36093a1c9b1264e7cb7f834d9ddd2311dade9c1f4
+      sha256: "1952250bd005bacb895a01bf1b4dc00e3ba1c526cf47dca54dfe24979c65f5b3"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "5.12.0"
   archive:
     dependency: transitive
     description:
       name: archive
-      sha256: ed7cc591a948744994714375caf9a2ce89e1d82e8243997c8a2994d57181c212
+      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.5"
+    version: "3.3.7"
   args:
     dependency: "direct main"
     description:
       name: args
-      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
+      sha256: c372bb384f273f0c2a8aaaa226dad84dc27c8519a691b888725dec59518ad53a
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.1"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   basic_utils:
     dependency: transitive
     description:
@@ -69,18 +69,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   chunked_stream:
     dependency: transitive
     description:
       name: chunked_stream
-      sha256: a8a0dcb519bd603b397cd242152fe76861d7c65200be58cb8114d96226252ad3
+      sha256: b2fde5f81d780f0c1699b8347cae2e413412ae947fc6e64727cc48c6bb54c95c
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   circular_buffer:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
@@ -117,26 +117,26 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "961c4aebd27917269b1896382c7cb1b1ba81629ba669ba09c27a7e5710ec9040"
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   csv:
     dependency: transitive
     description:
       name: csv
-      sha256: "18aef53ab72181a0b5384562d18c8cbd57e941e24cb8e54eb41409d3d8abdc6d"
+      sha256: "016b31a51a913744a0a1655c74ff13c9379e1200e246a03d96c81c5d9ed297b5"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.2"
   dart_console2:
     dependency: transitive
     description:
@@ -157,18 +157,18 @@ packages:
     dependency: "direct main"
     description:
       name: dcli
-      sha256: b830c100b1deb1ff3dbc2ff8c210d4638b7dd1b37de25ecf638b4e7bfe7ca771
+      sha256: "9d37d558960714690675c3f250aa94602d0ff701e654316944a5cea489618b80"
       url: "https://pub.dev"
     source: hosted
-    version: "1.36.0"
+    version: "1.36.2"
   dcli_core:
     dependency: transitive
     description:
       name: dcli_core
-      sha256: "144a6cbc697ee98d9720630eea7927cfeaac8970c53364ea0b229fb9586f143d"
+      sha256: "86c71b7bf3d93ca51ad3d64227acd3e595c98e4694aa3a48cce1c335409006b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.36.0"
+    version: "1.36.2"
   equatable:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   file:
     dependency: transitive
     description:
@@ -237,10 +237,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "0.13.6"
   http_multi_server:
     dependency: transitive
     description:
@@ -285,58 +285,58 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "323b7c70073cccf6b9b8d8b334be418a3293cfb612a560dc2737160a37bf61bd"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.6"
+    version: "0.6.7"
   json2yaml:
     dependency: transitive
     description:
       name: json2yaml
-      sha256: "1bd23a492025254aa14a760db94c8d52142c774ab3f2ab935e31742796bf505d"
+      sha256: da94630fbc56079426fdd167ae58373286f603371075b69bf46d848d63ba3e51
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.8.1"
   lint:
     dependency: "direct dev"
     description:
       name: lint
-      sha256: "4a539aa34ec5721a2c7574ae2ca0336738ea4adc2a34887d54b7596310b33c85"
+      sha256: f4bd4dbaa39f4ae8836f2d1275f2f32bc68b3a8cce0a0735dd1f7a601f06682a
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "2.1.2"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: c0bbfe94d46aedf9b8b3e695cf3bd48c8e14b35e3b2c639e0aa7755d589ba946
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.16"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -357,10 +357,10 @@ packages:
     dependency: transitive
     description:
       name: node_preamble
-      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -389,10 +389,10 @@ packages:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.2"
+    version: "3.7.3"
   pool:
     dependency: transitive
     description:
@@ -421,10 +421,10 @@ packages:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   pubspec2:
     dependency: transitive
     description:
@@ -437,10 +437,10 @@ packages:
     dependency: transitive
     description:
       name: pubspec_lock
-      sha256: "71a3d2fab24e3497bf732e70f78eabff835769b6a1963f9da0d06772f646af7f"
+      sha256: ed5fc1ecd0cdc0e14475a091afcb2c4cbb00e74cebff17635e9abbec18d76cc4
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   quiver:
     dependency: transitive
     description:
@@ -485,42 +485,42 @@ packages:
     dependency: transitive
     description:
       name: shelf
-      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   sidekick_core:
     dependency: "direct main"
     description:
       name: sidekick_core
-      sha256: eb99ba0ab27123cb8c309f358353d55fee741106e741c18b1220e81f757e8b9d
+      sha256: "87955e1a4f18ee647e5e016520a006417386fb3f70b8c35f8b4d905c0a3012d0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.2.0"
   sidekick_test:
     dependency: "direct dev"
     description:
@@ -542,18 +542,18 @@ packages:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "490098075234dcedb83c5d949b4c93dad5e6b7702748de000be2b57b8e6b2427"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.11"
+    version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -590,10 +590,10 @@ packages:
     dependency: transitive
     description:
       name: sum_types
-      sha256: af94bdbd220c90e1118a0b24453c52dc0593aa561ec613e7f5d6b576dde11958
+      sha256: c0a0fad9a518d011987e1d9f27fc336194294e55dafdc3699363e52aa5776e09
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.5"
   system_info2:
     dependency: transitive
     description:
@@ -614,34 +614,34 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: b54d427664c00f2013ffb87797a698883c46aee9288e027a50b46eaee7486fa2
+      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
       url: "https://pub.dev"
     source: hosted
-    version: "1.22.2"
+    version: "1.24.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.6.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "95ecc12692d0dd59080ab2d38d9cf32c7e9844caba23ff6cd285690398ee8ef4"
+      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.22"
+    version: "0.5.3"
   test_process:
     dependency: "direct dev"
     description:
       name: test_process
-      sha256: b0e6702f58272d459d5b80b88696483f86eac230dab05ecf73d0662e305d005e
+      sha256: "217f19b538926e4922bdb2a01410100ec4e3beb4cc48eae5ae6b20037b07bbd6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.0"
   time:
     dependency: transitive
     description:
@@ -654,10 +654,10 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   uuid:
     dependency: transitive
     description:
@@ -686,26 +686,26 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: d069ad658b700fc5fb774771ac8997f226ca29a45e0a450776fff3d969c8ba8f
+      sha256: f3743ca475e0c9ef71df4ba15eb2d7684eecd5c8ba20a462462e4e8b561b2e11
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "11.6.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -718,25 +718,25 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: c9ebe7ee4ab0c2194e65d3a07d8c54c5d00bb001b76081c4a04cdb8448b59e46
+      sha256: a6f0236dbda0f63aa9a25ad1ff9a9d8a4eaaa5012da0dc59d21afdb1dc361ca4
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.4"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   yaml_edit:
     dependency: transitive
     description:
       name: yaml_edit
-      sha256: "4240d1b19841b8af5786121e4e357735cc2a8ffb19176bff5769d73c34e2a8a5"
+      sha256: "1579d4a0340a83cf9e4d580ea51a16329c916973bffd5bd4b45e911b25d46bfd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.19.0-345.0.dev <4.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/sidekick/pubspec.yaml
+++ b/sidekick/pubspec.yaml
@@ -24,8 +24,14 @@ dependencies:
 
 dev_dependencies:
   lint: ^1.5.0
+  # Include again when updated to Dart 3
+  #sidekick_test:
+  #  path: ../sidekick_test
   sidekick_test:
-    path: ../sidekick_test
+    git:
+      url: https://github.com/phntmxyz/sidekick.git
+      ref: sidekick_core-v1.2.0
+      path: sidekick_test
   test: ^1.17.0
   test_process: ^2.0.2
 

--- a/sidekick/pubspec.yaml
+++ b/sidekick/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   sidekick_core: ^1.0.2
 
 dev_dependencies:
-  lint: ^1.5.0
+  lint: '>=1.5.0 <3.0.0'
   # Include again when updated to Dart 3
   #sidekick_test:
   #  path: ../sidekick_test

--- a/sidekick_core/lib/sidekick_core.dart
+++ b/sidekick_core/lib/sidekick_core.dart
@@ -1,10 +1,13 @@
+/// The core library for Sidekick CLIs
 library sidekick_core;
 
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dartx/dartx_io.dart';
 import 'package:dcli/dcli.dart';
+import 'package:path/path.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:sidekick_core/src/commands/update_command.dart';
 import 'package:sidekick_core/src/dart_package.dart';
@@ -14,10 +17,12 @@ import 'package:sidekick_core/src/version_checker.dart';
 
 export 'dart:io' hide sleep;
 
+export 'package:args/args.dart';
 export 'package:args/command_runner.dart';
 export 'package:dartx/dartx.dart';
 export 'package:dartx/dartx_io.dart';
-export 'package:dcli/dcli.dart' hide run, start, startFromArgs, absolute;
+export 'package:dcli/dcli.dart' hide run, start, startFromArgs;
+export 'package:path/path.dart' hide absolute;
 export 'package:pub_semver/pub_semver.dart' show Version;
 export 'package:sidekick_core/src/cli_util.dart';
 export 'package:sidekick_core/src/commands/analyze_command.dart';

--- a/sidekick_core/lib/src/dart_package.dart
+++ b/sidekick_core/lib/src/dart_package.dart
@@ -1,4 +1,4 @@
-import 'package:dcli/dcli.dart' show absolute;
+import 'package:path/path.dart' show absolute;
 import 'package:sidekick_core/sidekick_core.dart';
 import 'package:yaml/yaml.dart';
 

--- a/sidekick_core/lib/src/directory_ext.dart
+++ b/sidekick_core/lib/src/directory_ext.dart
@@ -1,6 +1,4 @@
-import 'dart:io';
-
-import 'package:dcli/dcli.dart';
+import 'package:sidekick_core/sidekick_core.dart';
 
 extension DirectoryExt on Directory {
   /// Recursively goes up and tries to find a [Directory] matching [predicate]

--- a/sidekick_core/lib/src/file_util.dart
+++ b/sidekick_core/lib/src/file_util.dart
@@ -1,4 +1,4 @@
-import 'package:dcli/dcli.dart' hide absolute;
+import 'package:dcli/dcli.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 
 extension FileModifier on File {

--- a/sidekick_core/lib/src/sidekick_package.dart
+++ b/sidekick_core/lib/src/sidekick_package.dart
@@ -3,7 +3,7 @@ import 'package:sidekick_core/sidekick_core.dart';
 
 /// The package that contains the generated sidekick cli code
 class SidekickPackage extends DartPackage {
-  SidekickPackage(Directory root, String name) : super(root, name);
+  SidekickPackage(super.root, super.name);
 
   static SidekickPackage? fromDirectory(Directory directory) {
     final dartPackage = DartPackage.fromDirectory(directory);

--- a/sidekick_core/lib/src/sidekick_package.dart
+++ b/sidekick_core/lib/src/sidekick_package.dart
@@ -1,4 +1,4 @@
-import 'package:dcli/dcli.dart';
+import 'package:path/path.dart' show absolute;
 import 'package:sidekick_core/sidekick_core.dart';
 
 /// The package that contains the generated sidekick cli code

--- a/sidekick_core/lib/src/template/sidekick_package.template.dart
+++ b/sidekick_core/lib/src/template/sidekick_package.template.dart
@@ -188,7 +188,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=2.18.6 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 executables:
   main:
@@ -197,7 +197,7 @@ dependencies:
   sidekick_core: $constraintRange
 
 dev_dependencies:
-  lint: ^1.5.3
+  lint: ^2.0.0
 
 # generated code, do not edit this manually
 sidekick:

--- a/sidekick_core/lib/src/update/migration.dart
+++ b/sidekick_core/lib/src/update/migration.dart
@@ -51,10 +51,10 @@ abstract class MigrationStep {
 class _InlineMigrationStep extends MigrationStep {
   const _InlineMigrationStep(
     this.block, {
-    required String name,
-    required Version targetVersion,
+    required super.name,
+    required super.targetVersion,
     this.pullRequestLink,
-  }) : super(name: name, targetVersion: targetVersion);
+  });
 
   /// Link to the pull request on GitHub introducing this patch
   final String? pullRequestLink;
@@ -79,12 +79,11 @@ class GitPatchMigrationStep extends MigrationStep {
     this.patch, {
     required this.description,
     this.pullRequestLink,
-    required Version targetVersion,
+    required super.targetVersion,
     required this.workingDirectory,
   }) : super(
           name:
               '$description${pullRequestLink != null ? ' ($pullRequestLink)' : ''}',
-          targetVersion: targetVersion,
         );
 
   /// A function that returns the git patch to be applied for this migration step

--- a/sidekick_core/pubspec.yaml
+++ b/sidekick_core/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
 
 dev_dependencies:
   fake_http_client: ^1.0.0
-  lint: '>=1.5.0 <3.0.0'
+  lint: ^2.0.0
   sidekick_test:
     path: ../sidekick_test
   test: ^1.20.0

--- a/sidekick_core/pubspec.yaml
+++ b/sidekick_core/pubspec.yaml
@@ -8,15 +8,16 @@ topics:
   - cli
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.19.0 <3.999.0'
 
 dependencies:
   args: ^2.1.0
   dartx: ^1.1.0
-  dcli: ^1.15.0
+  dcli: ^2.2.0
   glob: ^2.0.2
   http: ^0.13.5
   meta: ^1.5.0
+  path: ^1.8.1
   # transitive from dcli
   pub_semver: ^2.1.1
   recase: ^4.1.0
@@ -25,7 +26,7 @@ dependencies:
 
 dev_dependencies:
   fake_http_client: ^1.0.0
-  lint: ^1.5.0
+  lint: '>=1.5.0 <3.0.0'
   sidekick_test:
     path: ../sidekick_test
   test: ^1.20.0

--- a/sidekick_core/test/deps_command_test.dart
+++ b/sidekick_core/test/deps_command_test.dart
@@ -20,7 +20,7 @@ void main() {
 name: ${package.snakeCase}
 
 environment:
-  sdk: ^2.10.0
+  sdk: ^2.12.0
 ''');
     }
   }

--- a/sidekick_core/test/version_checker_test.dart
+++ b/sidekick_core/test/version_checker_test.dart
@@ -66,7 +66,7 @@ dependencies:
         pubspecYamlFile.readAsStringSync(),
         '''
 name: dashi
-dependencies: 
+dependencies:
   bar: 0.0.0
   foo: 1.2.4
 ''',

--- a/sidekick_plugin_installer/lib/sidekick_plugin_installer.dart
+++ b/sidekick_plugin_installer/lib/sidekick_plugin_installer.dart
@@ -1,3 +1,4 @@
+/// Support library for sidekick plugins
 library sidekick_plugin_installer;
 
 export 'package:sidekick_plugin_installer/src/add_dependency.dart';

--- a/sidekick_plugin_installer/pubspec.yaml
+++ b/sidekick_plugin_installer/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   sidekick_core: ^1.0.0
 
 dev_dependencies:
-  lint: ^1.0.0
+  lint: '>=1.5.0 <3.0.0'
   pubspec: ^2.3.0
   # Include again when updated to Dart 3
   #sidekick_test:

--- a/sidekick_plugin_installer/pubspec.yaml
+++ b/sidekick_plugin_installer/pubspec.yaml
@@ -18,6 +18,12 @@ dependencies:
 dev_dependencies:
   lint: ^1.0.0
   pubspec: ^2.3.0
+  # Include again when updated to Dart 3
+  #sidekick_test:
+  #  path: ../sidekick_test
   sidekick_test:
-    path: ../sidekick_test
+    git:
+      url: https://github.com/phntmxyz/sidekick.git
+      ref: sidekick_core-v1.2.0
+      path: sidekick_test
   test: '>1.21.0 <2.0.0'

--- a/sidekick_plugin_installer/test/add_dependency_test.dart
+++ b/sidekick_plugin_installer/test/add_dependency_test.dart
@@ -24,7 +24,7 @@ void main() {
 name: foo
 
 environment:
-  sdk: ^3.0.0
+  sdk: '>=2.19.0 <4.0.0'
 ''');
     package = DartPackage.fromDirectory(packageDir)!;
     overrideSidekickDartRuntimeWithSystemDartRuntime(packageDir);
@@ -42,7 +42,7 @@ environment:
 name: bar
 
 environment:
-  sdk: ^3.0.0
+  sdk: '>=2.19.0 <4.0.0'
 ''');
 
       addDependency(
@@ -57,7 +57,7 @@ environment:
 name: foo
 
 environment:
-  sdk: ^3.0.0
+  sdk: '>=2.19.0 <4.0.0'
 dependencies:
   bar:
     path: ${barDir.path}
@@ -78,7 +78,7 @@ dependencies:
 name: foo
 
 environment:
-  sdk: ^3.0.0
+  sdk: '>=2.19.0 <4.0.0'
 dependencies:
   sidekick_core: ^0.10.0
 ''',
@@ -99,7 +99,7 @@ dependencies:
 name: foo
 
 environment:
-  sdk: ^3.0.0
+  sdk: '>=2.19.0 <4.0.0'
 dependencies:
   sidekick_core:
     git:

--- a/sidekick_test/lib/fake_stdio.dart
+++ b/sidekick_test/lib/fake_stdio.dart
@@ -1,3 +1,4 @@
+/// Helper library for testing sidekick CLIs
 library sidekick_test;
 
 export 'src/fake_stdio.dart';

--- a/sidekick_test/lib/src/local_testing.dart
+++ b/sidekick_test/lib/src/local_testing.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:dartx/dartx_io.dart';
 import 'package:dcli/dcli.dart';
+import 'package:path/path.dart';
 import 'package:test/test.dart';
 
 /// True when dependencies should be linked to local sidekick dependencies
@@ -200,7 +201,7 @@ void _overrideDependency({
     ...pubspec.dependencyOverrides,
     dependency: Dependency.fromPath(dependency, path),
   };
-  pubspec.saveToFile(pubspecPath);
+  pubspec.save(pubspecPath);
 }
 
 /// Returns the Dart SDK of the `dart` executable on `PATH`

--- a/sidekick_test/pubspec.yaml
+++ b/sidekick_test/pubspec.yaml
@@ -1,17 +1,18 @@
 name: sidekick_test
 description: Shared utilities for testing sidekick packages.
-version: 1.0.0
+version: 2.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   args: ^2.1.0
   dartx: ^1.0.0
-  dcli: ^1.16.2
+  dcli: ^2.2.0
   mocktail: ^0.3.0
+  path: ^1.8.0
   test: ^1.17.0
 
 dev_dependencies:
-  lint: ^1.5.0
+  lint: ^2.0.0

--- a/sidekick_test/pubspec.yaml
+++ b/sidekick_test/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   dartx: ^1.0.0
   dcli: ^2.2.0
   mocktail: ^0.3.0
+  path: ^1.8.1
   test: ^1.17.0
 
 dev_dependencies:

--- a/sidekick_test/pubspec.yaml
+++ b/sidekick_test/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
   dartx: ^1.0.0
   dcli: ^2.2.0
   mocktail: ^0.3.0
-  path: ^1.8.0
   test: ^1.17.0
 
 dev_dependencies:

--- a/sidekick_test/pubspec.yaml
+++ b/sidekick_test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.19.0 <3.0.0'
+  sdk: '>=2.19.0 <3.999.0'
 
 dependencies:
   args: ^2.1.0

--- a/sidekick_vault/lib/sidekick_vault.dart
+++ b/sidekick_vault/lib/sidekick_vault.dart
@@ -1,3 +1,4 @@
+/// A library for storing secrets GPG encrypted in a directory
 library sidekick_vault;
 
 export 'package:sidekick_vault/src/commands/vault_command.dart';

--- a/sidekick_vault/pubspec.yaml
+++ b/sidekick_vault/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
 dev_dependencies:
   dcli_core: ^1.17.2
-  lint: ^1.5.0
+  lint: '>=1.5.0 <3.0.0'
   prompts: ^2.0.0
   sidekick_plugin_installer: ^0.3.0
   test: ^1.20.0

--- a/sidekick_vault/tool/install.dart
+++ b/sidekick_vault/tool/install.dart
@@ -1,6 +1,6 @@
 import 'package:dcli/dcli.dart' as dcli;
 import 'package:sidekick_core/sidekick_core.dart'
-    hide cliName, repository, mainProject;
+    hide cliName, mainProject, repository;
 import 'package:sidekick_plugin_installer/sidekick_plugin_installer.dart';
 
 Future<void> main() async {

--- a/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
+++ b/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
@@ -112,10 +112,8 @@ class LockDependenciesCommand extends Command {
       switch (type) {
         case 'transitive':
           transitiveDependencies[packageName] = range;
-          break;
         case 'direct main':
           directDependencies[packageName] = range;
-          break;
         // case 'direct dev' is irrelevant
       }
     }

--- a/sk_sidekick/lib/src/commands/release_command.dart
+++ b/sk_sidekick/lib/src/commands/release_command.dart
@@ -43,7 +43,7 @@ class ReleaseCommand extends Command {
     if (package == null) {
       print(green('Which package do you want to release?'));
       package = dcli.menu(
-        prompt: 'Select package',
+        'Select package',
         options: [
           skProject.sidekickPackage,
           skProject.sidekickCorePackage,
@@ -243,7 +243,7 @@ ${changelog.readAsStringSync().replaceFirst('# Changelog', '').trimLeft()}''');
       ),
     );
     return menu(
-      prompt: 'Please select a release type',
+      'Please select a release type',
       options: ['major', 'minor', 'patch'],
       defaultOption: 'minor',
       format: (option) {

--- a/sk_sidekick/pubspec.lock
+++ b/sk_sidekick/pubspec.lock
@@ -5,429 +5,498 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "405666cd3cf0ee0a48d21ec67e65406aad2c726d9fa58840d3375e7bdcd32a07"
+      url: "https://pub.dev"
     source: hosted
-    version: "52.0.0"
+    version: "60.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "1952250bd005bacb895a01bf1b4dc00e3ba1c526cf47dca54dfe24979c65f5b3"
+      url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "5.12.0"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.3.5"
+    version: "3.3.7"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: c372bb384f273f0c2a8aaaa226dad84dc27c8519a691b888725dec59518ad53a
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.1"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   basic_utils:
     dependency: transitive
     description:
       name: basic_utils
-      url: "https://pub.dartlang.org"
+      sha256: "8815477fcf58499e42326bd858e391442425fa57db9a45e48e15224c62049262"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.9.4"
+    version: "5.5.4"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   chunked_stream:
     dependency: transitive
     description:
       name: chunked_stream
-      url: "https://pub.dartlang.org"
+      sha256: b2fde5f81d780f0c1699b8347cae2e413412ae947fc6e64727cc48c6bb54c95c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   circular_buffer:
     dependency: transitive
     description:
       name: circular_buffer
-      url: "https://pub.dartlang.org"
+      sha256: "2889afcfc97aa0d9a4930ae5fdf206aea7d0ac88a3649acec9130565cd8f45d8"
+      url: "https://pub.dev"
     source: hosted
     version: "0.11.0"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      sha256: b8db3080e59b2503ca9e7922c3df2072cf13992354d5e944074ffa836fba43b7
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.2"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   csv:
     dependency: transitive
     description:
       name: csv
-      url: "https://pub.dartlang.org"
+      sha256: "016b31a51a913744a0a1655c74ff13c9379e1200e246a03d96c81c5d9ed297b5"
+      url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.2"
   dart_console2:
     dependency: transitive
     description:
       name: dart_console2
-      url: "https://pub.dartlang.org"
+      sha256: "300833ffdd8c465d454cb5007c7f29d28ac8246af5abd922f8c490e1e87c894f"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   dartx:
     dependency: transitive
     description:
       name: dartx
-      url: "https://pub.dartlang.org"
+      sha256: "45d7176701f16c5a5e00a4798791c1964bc231491b879369c818dd9a9c764871"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   dcli:
     dependency: "direct main"
     description:
       name: dcli
-      url: "https://pub.dartlang.org"
+      sha256: a5e5d77a1b57b6590ac6a15e7be3307c398283606ffe0c608ce600d47204839d
+      url: "https://pub.dev"
     source: hosted
-    version: "1.36.0"
+    version: "2.2.2"
   dcli_core:
     dependency: transitive
     description:
       name: dcli_core
-      url: "https://pub.dartlang.org"
+      sha256: "441ebd54e5f0b549516537e82c8e62ca866351d7abff99183c9b8a8bdf324506"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.36.0"
+    version: "2.2.2"
   equatable:
     dependency: transitive
     description:
       name: equatable
-      url: "https://pub.dartlang.org"
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
-  file_utils:
-    dependency: transitive
-    description:
-      name: file_utils
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   functional_data:
     dependency: transitive
     description:
       name: functional_data
-      url: "https://pub.dartlang.org"
+      sha256: "950f886463a7531a3b77904e0eb89e8e06dda78c4e3f5a84686445a2290cce18"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   globbing:
     dependency: transitive
     description:
       name: globbing
-      url: "https://pub.dartlang.org"
+      sha256: "4f89cfaf6fa74c9c1740a96259da06bd45411ede56744e28017cc534a12b6e2d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   http:
     dependency: transitive
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "0.13.6"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   ini:
     dependency: transitive
     description:
       name: ini
-      url: "https://pub.dartlang.org"
+      sha256: "12a76c53591ffdf86d1265be3f986888a6dfeb34a85957774bc65912d989a173"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   intl:
     dependency: transitive
     description:
       name: intl
-      url: "https://pub.dartlang.org"
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.18.1"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json2yaml:
     dependency: transitive
     description:
       name: json2yaml
-      url: "https://pub.dartlang.org"
+      sha256: da94630fbc56079426fdd167ae58373286f603371075b69bf46d848d63ba3e51
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "4.8.1"
   lint:
     dependency: "direct dev"
     description:
       name: lint
-      url: "https://pub.dartlang.org"
+      sha256: f4bd4dbaa39f4ae8836f2d1275f2f32bc68b3a8cce0a0735dd1f7a601f06682a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "2.1.2"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.15"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   mocktail:
     dependency: transitive
     description:
       name: mocktail
-      url: "https://pub.dartlang.org"
+      sha256: "80a996cd9a69284b3dc521ce185ffe9150cde69767c2d3a0720147d93c0cef53"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.6.2"
+    version: "3.7.3"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   posix:
     dependency: transitive
     description:
       name: posix
-      url: "https://pub.dartlang.org"
+      sha256: "3ad26924254fd2354b0e2b95fc8b45ac392ad87434f8e64807b3a1ac077f2256"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "5.0.0"
   pub_semver:
     dependency: "direct main"
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   pubspec2:
     dependency: transitive
     description:
       name: pubspec2
-      url: "https://pub.dartlang.org"
+      sha256: "7b1fd81927f1da6d88457c83b51134e1bc8cb07638bd8d9e205b2ce1cd9ec091"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
   pubspec_lock:
     dependency: transitive
     description:
       name: pubspec_lock
-      url: "https://pub.dartlang.org"
+      sha256: ed5fc1ecd0cdc0e14475a091afcb2c4cbb00e74cebff17635e9abbec18d76cc4
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   quiver:
     dependency: transitive
     description:
       name: quiver
-      url: "https://pub.dartlang.org"
+      sha256: b1c1ac5ce6688d77f65f3375a9abb9319b3cb32486bdc7a1e0fdf004d7ba4e47
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   random_string:
     dependency: transitive
     description:
       name: random_string
-      url: "https://pub.dartlang.org"
+      sha256: "03b52435aae8cbdd1056cf91bfc5bf845e9706724dd35ae2e99fa14a1ef79d02"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   recase:
     dependency: transitive
     description:
       name: recase
-      url: "https://pub.dartlang.org"
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
   scope:
     dependency: transitive
     description:
       name: scope
-      url: "https://pub.dartlang.org"
+      sha256: e0c880d8f0db2ffd2accd63eeb02396748f3b8a2f71bce4b7d3f8dab75fc8a74
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   settings_yaml:
     dependency: transitive
     description:
       name: settings_yaml
-      url: "https://pub.dartlang.org"
+      sha256: "7b24fabf8595da060cb98d72541d594c3d3c706272b4d7bec70b251473257909"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "6.0.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   sidekick_core:
     dependency: "direct main"
     description:
@@ -441,181 +510,198 @@ packages:
       path: "../sidekick_test"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "2.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.10.11"
+    version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
-  stacktrace_impl:
-    dependency: transitive
-    description:
-      name: stacktrace_impl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.3.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   sum_types:
     dependency: transitive
     description:
       name: sum_types
-      url: "https://pub.dartlang.org"
+      sha256: c0a0fad9a518d011987e1d9f27fc336194294e55dafdc3699363e52aa5776e09
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.5"
   system_info2:
     dependency: transitive
     description:
       name: system_info2
-      url: "https://pub.dartlang.org"
+      sha256: "65206bbef475217008b5827374767550a5420ce70a04d2d7e94d1d2253f3efc9"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "4.0.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "4f92f103ef63b1bbac6f4bd1930624fca81b2574464482512c4f0896319be575"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.22.2"
+    version: "1.24.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: daadc9baabec998b062c9091525aa95786508b1c48e9c30f1f891b8bf6ff2e64
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.5.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "3642b184882f79e76ca57a9230fb971e494c3c1fd09c21ae3083ce891bcc0aa1"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.22"
+    version: "0.5.2"
   time:
     dependency: transitive
     description:
       name: time
-      url: "https://pub.dartlang.org"
+      sha256: "83427e11d9072e038364a5e4da559e85869b227cf699a541be0da74f14140124"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
+  uri:
+    dependency: transitive
+    description:
+      name: uri
+      sha256: "889eea21e953187c6099802b7b4cf5219ba8f3518f604a1033064d45b1b8268a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      url: "https://pub.dartlang.org"
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
   validators2:
     dependency: transitive
     description:
       name: validators2
-      url: "https://pub.dartlang.org"
+      sha256: "5c63054b2f47b6a3f39e0d0e3f5d38829db4545250144a34c9e1585466de4814"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
-  vin_decoder:
-    dependency: transitive
-    description:
-      name: vin_decoder
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.1-nullsafety"
+    version: "5.0.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: f3743ca475e0c9ef71df4ba15eb2d7684eecd5c8ba20a462462e4e8b561b2e11
+      url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "11.6.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   win32:
     dependency: transitive
     description:
       name: win32
-      url: "https://pub.dartlang.org"
+      sha256: "5a751eddf9db89b3e5f9d50c20ab8612296e4e8db69009788d6c8b060a84191c"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "4.1.4"
   yaml:
     dependency: "direct main"
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   yaml_edit:
     dependency: transitive
     description:
       name: yaml_edit
-      url: "https://pub.dartlang.org"
+      sha256: "1579d4a0340a83cf9e4d580ea51a16329c916973bffd5bd4b45e911b25d46bfd"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.18.7 <3.0.0"
+  dart: ">=3.0.0 <3.999.0"

--- a/sk_sidekick/pubspec.lock
+++ b/sk_sidekick/pubspec.lock
@@ -370,7 +370,7 @@ packages:
     source: hosted
     version: "2.1.0"
   path:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: path
       sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"

--- a/sk_sidekick/pubspec.yaml
+++ b/sk_sidekick/pubspec.yaml
@@ -4,20 +4,21 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 executables:
   main:
 
 dependencies:
-  dcli: ^1.15.0
+  dcli: ^2.2.2
+  path: ^1.8.0
   pub_semver: ^2.1.1
   sidekick_core:
     path: ../sidekick_core
   yaml: ^3.1.1
 
 dev_dependencies:
-  lint: ^1.5.3
+  lint: ^2.0.0
   sidekick_test:
     path: ../sidekick_test
   test: ^1.20.0

--- a/sk_sidekick/pubspec.yaml
+++ b/sk_sidekick/pubspec.yaml
@@ -11,7 +11,6 @@ executables:
 
 dependencies:
   dcli: ^2.2.2
-  path: ^1.8.0
   pub_semver: ^2.1.1
   sidekick_core:
     path: ../sidekick_core


### PR DESCRIPTION
### sidekick_core

- Become compatible with Dart 3
- Raise min Dart SDK to 2.19
- Update to [dcli:2.2.0](https://pub.dev/packages/dcli/changelog#220), this forces us to upgrade to 2.19. This also causes some breaking changes, hence sidekick_core required a major version bump
- `args` and `path` are now directly exported from `sidekick_core`, where exported from dcli previously

### sidekick_test

- Become compatible with Dart 3
- Raise min Dart SDK to 2.19

### sk_sidekick

- Use Dart 3 / dcli 2.2.0
