### PR TITLE
Show warning when using deps in the wrong folder

### DIFF
--- a/sidekick_core/lib/src/commands/deps_command.dart
+++ b/sidekick_core/lib/src/commands/deps_command.dart
@@ -60,11 +60,13 @@ class DepsCommand extends Command {
         throw "Package with name $packageName not found in "
             "${SidekickContext.projectRoot.path}";
       }
+      _warnIfNotInProject();
       // only get deps for selected package
       _getDependencies(package);
       return;
     }
 
+    _warnIfNotInProject();
     final errorBuffer = StringBuffer();
 
     final globExcludes = excludeGlob
@@ -114,4 +116,24 @@ class DepsCommand extends Command {
     );
     print("\n");
   }
+
+  void _warnIfNotInProject() {
+    final currentDir = Directory.current;
+    final projectRoot = SidekickContext.projectRoot;
+    if (!currentDir.isWithinOrEqual(projectRoot)) {
+      printerr("Warning: You aren't getting the dependencies of the current "
+          "working directory, but of project '${SidekickContext.cliName}'.");
+    }
+  }
+}
+
+extension on Directory {
+  bool isWithinOrEqual(Directory dir) {
+    return this.isWithin(dir) ||
+        // canonicalize is necessary, otherwise '/a/b/c' != '/a/b/c/' != '/a/b/c/.' != '/a/b/c/../c'
+        dir.canonicalized.path == canonicalized.path;
+  }
+
+  /// A [Directory] whose path is the canonicalized path of [this].
+  Directory get canonicalized => Directory(canonicalize(path));
 }


### PR DESCRIPTION
Fixes #42 

Prints a warning when using the deps command outside of the project