### PR TITLE
Constrain `pubspec2` dependency in `sidekick_core`

### DIFF
--- a/sidekick_core/lib/src/template/update_executor.template.dart
+++ b/sidekick_core/lib/src/template/update_executor.template.dart
@@ -55,7 +55,9 @@ environment:
   sdk: '>=${dartSdkVersion.canonicalizedVersion} <${dartSdkVersion.nextBreaking.canonicalizedVersion}'
 dependencies:
   sidekick_core: ${newSidekickCoreVersion.canonicalizedVersion}
-
+dependency_overrides:
+  # `pubspec2` is a transitive dependency of `dcli`, but `pubspec2` v2.5.0 breaks `dcli` v2 (see https://github.com/onepub-dev/dcli/issues/218)
+  pubspec2: '>=2.0.0 <2.5.0'
 ''');
 
     final updateScript = location.file('bin/update.dart')

--- a/sidekick_core/lib/src/template/update_executor.template.dart
+++ b/sidekick_core/lib/src/template/update_executor.template.dart
@@ -56,6 +56,7 @@ environment:
 dependencies:
   sidekick_core: ${newSidekickCoreVersion.canonicalizedVersion}
   pubspec2: '>=2.0.0 <2.5.0'
+
 ''');
 
     final updateScript = location.file('bin/update.dart')

--- a/sidekick_core/lib/src/template/update_executor.template.dart
+++ b/sidekick_core/lib/src/template/update_executor.template.dart
@@ -55,8 +55,6 @@ environment:
   sdk: '>=${dartSdkVersion.canonicalizedVersion} <${dartSdkVersion.nextBreaking.canonicalizedVersion}'
 dependencies:
   sidekick_core: ${newSidekickCoreVersion.canonicalizedVersion}
-dependency_overrides:
-  # `pubspec2` is a transitive dependency of `dcli`, but `pubspec2` v2.5.0 breaks `dcli` v2 (see https://github.com/onepub-dev/dcli/issues/218)
   pubspec2: '>=2.0.0 <2.5.0'
 ''');
 

--- a/sidekick_core/pubspec.yaml
+++ b/sidekick_core/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   yaml_edit: ^2.0.3
 
 dependency_overrides:
-  # `pubspec2` is a transitive dependency of `dcli`, but `pubspec2` v2.5.0 breaks `dcli` v2.2.3
+  # `pubspec2` is a transitive dependency of `dcli`, but `pubspec2` v2.5.0 breaks `dcli` v2 (see https://github.com/onepub-dev/dcli/issues/218)
   pubspec2: '>=2.0.0 <2.5.0'
 
 dev_dependencies:

--- a/sidekick_core/pubspec.yaml
+++ b/sidekick_core/pubspec.yaml
@@ -20,14 +20,12 @@ dependencies:
   path: ^1.8.1
   # transitive from dcli
   pub_semver: ^2.1.1
+  # `pubspec2` is a transitive dependency of `dcli`, but `pubspec2` v2.5.0 breaks `dcli` v2 (see https://github.com/onepub-dev/dcli/issues/218)
+  pubspec2: '>=2.0.0 <2.5.0'
   pubspec_parse: ^1.2.0
   recase: ^4.1.0
   yaml: ^3.1.0
   yaml_edit: ^2.0.3
-
-dependency_overrides:
-  # `pubspec2` is a transitive dependency of `dcli`, but `pubspec2` v2.5.0 breaks `dcli` v2 (see https://github.com/onepub-dev/dcli/issues/218)
-  pubspec2: '>=2.0.0 <2.5.0'
 
 dev_dependencies:
   fake_http_client: ^1.0.0

--- a/sidekick_core/pubspec.yaml
+++ b/sidekick_core/pubspec.yaml
@@ -25,6 +25,10 @@ dependencies:
   yaml: ^3.1.0
   yaml_edit: ^2.0.3
 
+dependency_overrides:
+  # `pubspec2` is a transitive dependency of `dcli`, but `pubspec2` v2.5.0 breaks `dcli` v2.2.3
+  pubspec2: '>=2.0.0 <2.5.0'
+
 dev_dependencies:
   fake_http_client: ^1.0.0
   lint: ^2.0.0

--- a/sidekick_core/test/update/update_2_0_0_test.dart
+++ b/sidekick_core/test/update/update_2_0_0_test.dart
@@ -17,6 +17,7 @@ void main() {
     });
     tempDir.file('test').writeAsString('# entrypoint file');
     final pubspecFile = sidekickDir.file('pubspec.yaml');
+    final oldHttpVersion = Version(0, 13, 6);
     pubspecFile.writeAsStringSync('''
 name: test_sidekick
 
@@ -25,7 +26,7 @@ environment:
 
 dependencies:
   # http updated to 1.0.0 with Dart 3 
-  http: ^0.13.6
+  http: ^$oldHttpVersion
 ''');
 
     overrideSidekickDartRuntimeWithSystemDartRuntime(sidekickDir);
@@ -62,7 +63,7 @@ dependencies:
     );
 
     expect(httpVersion, isNotNull);
-    expect(httpVersion!.allows(Version(1, 0, 0)), isTrue);
+    expect(httpVersion!.major, greaterThan(oldHttpVersion.major));
 
     final Version? coreVersion = VersionChecker.getMinimumVersionConstraint(
       DartPackage.fromDirectory(sidekickDir)!,


### PR DESCRIPTION
`sidekick_core` transitively depends on `pubspec2` through `dcli`. A new version (`2.5.0`) of `pubspec2` was released today. However, this new version is incompatible with `dcli` `2.2.3` which `sidekick_core` uses. So the transitive dependency has to be constrained to the previously used older version.

https://github.com/onepub-dev/dcli/issues/218

```
../../../.pub-cache/hosted/pub.dev/dcli-2.2.3/lib/src/commands/lock.dart:123:36: Error: Too many positional arguments: 3 allowed, but 4 found.
Try removing the extra positional arguments.
            ExternalHostedReference(hosted.package, hosted.url, version, false)
                                   ^
../../../.pub-cache/hosted/pub.dev/pubspec2-2.5.0/lib/src/dependency.dart:151:9: Context: Found this candidate, but the arguments don't match.
  const ExternalHostedReference(this.name, this.url, this.versionConstraint,
        ^^^^^^^^^^^^^^^^^^^^^^^
```