### PR TITLE
Fix bug in `shared-command` plugin template when plugin name ends with `_sidekick_plugin`

### DIFF
--- a/sidekick/test/plugins_test.dart
+++ b/sidekick/test/plugins_test.dart
@@ -109,8 +109,10 @@ void main() {
               // plugin code should be valid
               if (analyzeGeneratedCode) {
                 run('dart pub get', workingDirectory: pluginDir.path);
-                run('dart analyze --fatal-infos',
-                    workingDirectory: pluginDir.path);
+                run(
+                  'dart analyze --fatal-infos',
+                  workingDirectory: pluginDir.path,
+                );
                 run('dart format --set-exit-if-changed ${pluginDir.path}');
               }
               expect(

--- a/sidekick_core/lib/src/commands/plugins/create_templates/install_only.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/install_only.dart
@@ -29,6 +29,10 @@ extension on PluginTemplateProperties {
 name: $pluginName
 description: Generated sidekick plugin (template install-only)
 version: 0.0.1
+topics:
+  - sidekick
+  - cli
+  - sidekick-plugin
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/sidekick_core/lib/src/commands/plugins/create_templates/install_only.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/install_only.dart
@@ -49,15 +49,15 @@ import 'package:sidekick_plugin_installer/sidekick_plugin_installer.dart';
 Future<void> main() async {
   final SidekickPackage package = PluginContext.sidekickPackage;
 
-  final commandFile = package.root.file('lib/src/${pluginName.snakeCase}.dart');
-  commandFile.writeAsStringSync("""
+  final commandFile = package.root.file('lib/src/commands/${pluginName.snakeCase}.dart');
+  commandFile..createSync(recursive: true)..writeAsStringSync("""
 $exampleCommand
 """);
 
   registerPlugin(
     sidekickCli: package,
-    import: "import 'package:\${package.name}/src/${pluginName.snakeCase}.dart';",
-    command: '${pluginName.pascalCase}Command()',
+    import: "import 'package:\${package.name}/src/commands/${pluginName.snakeCase}.dart';",
+    command: '${commandName.pascalCase}Command()',
   );
 }
 ''';
@@ -65,14 +65,14 @@ $exampleCommand
   String get exampleCommand => '''
 import 'package:sidekick_core/sidekick_core.dart';
 
-class ${pluginName.pascalCase}Command extends Command {
+class ${commandName.pascalCase}Command extends Command {
   @override
   final String description = 'Sample command';
 
   @override
-  final String name = '${pluginName.paramCase}';
+  final String name = '$commandName';
 
-  ${pluginName.pascalCase}Command() {
+  ${commandName.pascalCase}Command() {
     // add parameters here with argParser.addOption
   }
 

--- a/sidekick_core/lib/src/commands/plugins/create_templates/plugin_template_generator.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/plugin_template_generator.dart
@@ -28,9 +28,12 @@ class PluginTemplateProperties {
   final String pluginName;
 
   /// The name of the command that will be generated
-  String get commandName {
-    return pluginName.replaceAll('_sidekick_plugin', '').paramCase;
-  }
+  late final String commandName = pluginName
+      .removePrefix('sidekick_')
+      .removePrefix('plugin_')
+      .removeSuffix('_plugin')
+      .removeSuffix('_sidekick')
+      .paramCase;
 
   /// Where the files should be written to. This is considered as root directory
   final Directory pluginDirectory;
@@ -38,7 +41,7 @@ class PluginTemplateProperties {
   /// The type of template to generate. Also see [CreatePluginCommand.templates]
   final String templateType;
 
-  const PluginTemplateProperties({
+  PluginTemplateProperties({
     required this.pluginName,
     required this.pluginDirectory,
     required this.templateType,

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
@@ -43,6 +43,10 @@ extension on PluginTemplateProperties {
 name: $pluginName
 description: Generated sidekick plugin (template shared-code)
 version: 0.0.1
+topics:
+  - sidekick
+  - cli
+  - sidekick-plugin
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_code.dart
@@ -30,7 +30,7 @@ class SharedCodeTemplate extends PluginTemplateGenerator {
     final templateDirectory = pluginDirectory.directory('template')
       ..createSync();
     final pluginCommandTemplateFile = templateDirectory
-        .file('${props.pluginName.snakeCase}_command.template.dart')
+        .file('commands/${props.commandName.snakeCase}_command.template.dart')
       ..createSync(recursive: true);
     pluginCommandTemplateFile.writeAsStringSync(props.exampleCommand);
 
@@ -67,18 +67,19 @@ Future<void> main() async {
   pubGet(package);
   
   final cliCommandFile =
-      package.root.file('lib/src/${pluginName.snakeCase}_command.dart');
+      package.root.file('lib/src/commands/${commandName.snakeCase}_command.dart');
+  cliCommandFile.createSync(recursive: true);
 
   PluginContext
       .installerPlugin
       .root
-      .file('template/${pluginName.snakeCase}_command.template.dart')
+      .file('template/commands/${commandName.snakeCase}_command.template.dart')
       .copySync(cliCommandFile.path);
   
   registerPlugin(
     sidekickCli: package,
-    import: "import 'package:\${package.name}/src/${pluginName.snakeCase}_command.dart';",
-    command: '${pluginName.pascalCase}Command()',
+    import: "import 'package:\${package.name}/src/commands/${commandName.snakeCase}_command.dart';",
+    command: '${commandName.pascalCase}Command()',
   );
 }
 ''';
@@ -89,14 +90,14 @@ ${[
         "import 'package:$pluginName/${pluginName.snakeCase}.dart';",
       ].sorted().join('\n')}
 
-class ${pluginName.pascalCase}Command extends Command {
+class ${commandName.pascalCase}Command extends Command {
   @override
   final String description = 'Sample command';
 
   @override
-  final String name = '${pluginName.paramCase}';
+  final String name = '$commandName';
 
-  ${pluginName.pascalCase}Command() {
+  ${commandName.pascalCase}Command() {
     // add parameters here with argParser.addOption
   }
 

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
@@ -43,6 +43,10 @@ extension on PluginTemplateProperties {
 name: $pluginName
 description: Generated sidekick plugin (template shared-command)
 version: 0.0.1
+topics:
+  - sidekick
+  - cli
+  - sidekick-plugin
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_templates/shared_command.dart
@@ -28,9 +28,11 @@ class SharedCommandTemplate extends PluginTemplateGenerator {
         .writeAsStringSync(props.library);
 
     final srcDir = libDirectory.directory('src')..createSync();
-    srcDir
-        .file('${props.commandName.snakeCase}_command.dart')
-        .writeAsStringSync(props.exampleCommand);
+    final commandFile =
+        srcDir.file('commands/${props.commandName.snakeCase}_command.dart');
+    commandFile
+      ..createSync(recursive: true)
+      ..writeAsStringSync(props.exampleCommand);
 
     super.generate(props);
   }
@@ -66,8 +68,8 @@ Future<void> main() async {
 
   registerPlugin(
     sidekickCli: package,
-    import: "import 'package:$pluginName/${pluginName.snakeCase}.dart';",
-    command: '${pluginName.pascalCase}Command()',
+    import: "import 'package:$pluginName/$pluginName.dart';",
+    command: '${commandName.pascalCase}Command()',
   );
 }
 ''';
@@ -76,7 +78,7 @@ Future<void> main() async {
 /// Sidekick plugin ${pluginName.titleCase}
 library ${pluginName.snakeCase};
 
-export 'package:${pluginName.snakeCase}/src/${commandName.snakeCase}_command.dart';
+export 'package:${pluginName.snakeCase}/src/commands/${commandName.snakeCase}_command.dart';
 ''';
 
   String get exampleCommand => '''


### PR DESCRIPTION
Fixes #240 

Contains some improvements to other templates as well:
- If plugin name is `foo_sidekick_plugin` (or `sidekick_plugin_foo`), the generated plugin command will be named `foo` now instead of `foo_sidekick_plugin` (or `sidekick_plugin_foo`)
- Generated plugins now have a `topics` field with tags to make finding sidekick plugins easier
- Sample plugin command is now placed in `src/commands`
- When installing `shared-command` plugin now the whole plugin package is imported instead of `src/foo_command.dart`