### PR TITLE
Add tab completion

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -22,6 +22,7 @@ jobs:
       image: dart:${{ matrix.version }}
 
     steps:
+      - run: echo "${HOME}/.sidekick/bin" >> $GITHUB_PATH
       - run: |
           apt-get update
           apt-get install unzip
@@ -49,6 +50,7 @@ jobs:
       image: dart:${{ matrix.version }}
 
     steps:
+      - run: echo "${HOME}/.sidekick/bin" >> $GITHUB_PATH
       - run: |
          apt-get update
          apt-get install unzip

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -26,6 +26,8 @@ jobs:
           apt-get update
           apt-get install unzip
       - uses: actions/checkout@v1
+      - name: Dart version
+        run: dart --version
       - name: Install dependencies
         run: cd sidekick && dart pub get --no-precompile
       - name: Run tests
@@ -51,6 +53,8 @@ jobs:
          apt-get update
          apt-get install unzip
       - uses: actions/checkout@v1
+      - name: Dart version
+        run: dart --version
       - name: Install dependencies
         run: cd sidekick && dart pub get --no-precompile
       - name: Run tests

--- a/sidekick/lib/sidekick.dart
+++ b/sidekick/lib/sidekick.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:cli_completion/cli_completion.dart';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:sidekick/src/commands/init_command.dart';
@@ -27,7 +28,7 @@ Future<void> main(List<String> args) async {
 }
 
 @visibleForTesting
-class GlobalSidekickCommandRunner extends CommandRunner {
+class GlobalSidekickCommandRunner extends CompletionCommandRunner<void> {
   GlobalSidekickCommandRunner({
     this.processManager = const LocalProcessManager(),
   }) : super('sidekick', _desc) {

--- a/sidekick/lib/src/commands/init_command.dart
+++ b/sidekick/lib/src/commands/init_command.dart
@@ -266,7 +266,7 @@ class InitCommand extends Command {
 
     final flutterPackages = [
       if (inputs.mainProject != null) inputs.mainProject!,
-      ...inputs.packages
+      ...inputs.packages,
     ].filter((package) => package.isFlutterPackage).toSet();
 
     if (flutterPackages.isNotEmpty) {

--- a/sidekick/pubspec.lock
+++ b/sidekick/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.0"
+  cli_completion:
+    dependency: "direct main"
+    description:
+      name: cli_completion
+      sha256: "595b192451285749369e99b3c2fd9a9aea7d74ed1aba61cddeb9ad8c84a44812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   cli_util:
     dependency: transitive
     description:
@@ -337,6 +345,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  mason_logger:
+    dependency: transitive
+    description:
+      name: mason_logger
+      sha256: c12860ae81f0bdc5d05d7914fe473bfb294047e9dc64e8995b5753c7207e81b9
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   matcher:
     dependency: transitive
     description:

--- a/sidekick/pubspec.yaml
+++ b/sidekick/pubspec.yaml
@@ -13,6 +13,7 @@ environment:
 dependencies:
   acronym: ^0.5.1
   args: ^2.3.2
+  cli_completion: ^0.3.0
   dartx: ^1.0.0
   dcli: '>=2.2.0 <=2.2.3'
   http: '>=0.13.3 <=2.0.0'

--- a/sidekick/test/init_test.dart
+++ b/sidekick/test/init_test.dart
@@ -87,7 +87,7 @@ void main() {
             '--projectRoot',
             projectRoot.path,
             '--cliPackageDirectory',
-            tempDir.path
+            tempDir.path,
           ],
           workingDirectory: projectRoot,
         );
@@ -126,7 +126,7 @@ void main() {
             '--projectRoot',
             projectRoot.path,
             '--mainProjectPath',
-            tempDir.path
+            tempDir.path,
           ],
           workingDirectory: projectRoot,
         );
@@ -164,7 +164,7 @@ void main() {
             '--projectRoot',
             projectRoot.path,
             '--mainProjectPath',
-            tempDir.path
+            tempDir.path,
           ],
           workingDirectory: projectRoot,
         );
@@ -269,7 +269,7 @@ void main() {
         // fake flutter installation because we don't have flutter installed on CI
         final pathWithFakeFlutterSdk = [
           fakeFlutterSdk().directory('bin').path,
-          ...PATH
+          ...PATH,
         ].join(env.delimiterForPATH);
 
         final dartDashProcess = await TestProcess.start(

--- a/sidekick/test/tab_completion_test.dart
+++ b/sidekick/test/tab_completion_test.dart
@@ -28,36 +28,47 @@ void main() {
   setUp(uninstallGlobalCli);
   tearDown(uninstallGlobalCli);
 
-  test('Prints info when tab completions are not installed', () async {
-    await withSidekickCli((cli) async {
-      final p = await cli.run([]);
-
-      final command = yellow('dashi sidekick install-global');
-      final expectedMessage =
-          '${cyan('Run')} $command ${cyan('to enable tab completion.')}';
-
-      final stdout = await p.stdoutStream().toList();
-      expect(stdout, contains(expectedMessage));
-    });
-  });
-
-  test('Tab prints completions', () async {
-    await withSidekickCli(
-      (cli) async {
-        await expectLater(
-          'dashi',
-          cli.suggests({
-            'dart': 'Calls dart',
-            'deps': 'Gets dependencies for all packages',
-            'clean': 'Cleans the project',
-            'analyze': 'Dart analyzes the whole project',
-            'format': 'Formats all Dart files in the repository.',
-            'sidekick': 'Manages the sidekick CLI',
-            '--help': 'Print this usage information.',
-            '--version': 'Print the sidekick version of this CLI.',
-          }),
+  test(
+    'Prints info when tab completions are not installed',
+    () async {
+      await withSidekickCli((cli) async {
+        final p = await cli.run([]);
+        final stdout = await p.stderrStream().toList();
+        expect(
+          stdout,
+          containsAllInOrder([
+            '💡Tip:',
+            'Run',
+            './dashi sidekick install-global',
+            'to enable tab completion',
+          ]),
         );
-      },
-    );
-  });
+      });
+    },
+    timeout: const Timeout(Duration(seconds: 90)),
+  );
+
+  test(
+    'Tab prints completions',
+    () async {
+      await withSidekickCli(
+        (cli) async {
+          await expectLater(
+            'dashi',
+            cli.suggests({
+              'dart': 'Calls dart',
+              'deps': 'Gets dependencies for all packages',
+              'clean': 'Cleans the project',
+              'analyze': 'Dart analyzes the whole project',
+              'format': 'Formats all Dart files in the repository.',
+              'sidekick': 'Manages the sidekick CLI',
+              '--help': 'Print this usage information.',
+              '--version': 'Print the sidekick version of this CLI.',
+            }),
+          );
+        },
+      );
+    },
+    timeout: const Timeout(Duration(seconds: 90)),
+  );
 }

--- a/sidekick/test/tab_completion_test.dart
+++ b/sidekick/test/tab_completion_test.dart
@@ -29,13 +29,70 @@ void main() {
   tearDown(uninstallGlobalCli);
 
   test(
+    'Does not print info when tab completions are installed',
+    () async {
+      await withSidekickCli((cli) async {
+        await cli.run(['sidekick', 'install-global']);
+        final p = await cli.run([]);
+        final stderr = await p.stderrStream().join('\n');
+        expect(
+          stderr,
+          isNot(
+            anyOf([
+              contains('💡Tip:'),
+              contains('Run'),
+              contains('./dashi sidekick install-global'),
+              contains('to enable tab completion'),
+            ]),
+          ),
+        );
+      });
+    },
+    timeout: const Timeout(Duration(seconds: 90)),
+  );
+
+  test(
+    'Does not print installation tip when running install-global but prints info on sourcing start script',
+    () async {
+      await withSidekickCli((cli) async {
+        final p = await cli.run(['sidekick', 'install-global']);
+        final stderr = await p.stderrStream().join('\n');
+
+        expect(
+          stderr,
+          isNot(
+            anyOf([
+              contains('💡Tip: Run'),
+              contains('./dashi sidekick install-global'),
+              contains('to enable tab completion'),
+            ]),
+          ),
+        );
+        expect(
+          stderr,
+          allOf([
+            contains('Run'),
+            contains('source'),
+            anyOf([
+              contains(Shell.current.pathToStartScript),
+              contains('~/.bashrc'),
+            ]),
+            contains('or restart your terminal to activate tab completion'),
+          ]),
+        );
+      });
+    },
+    timeout: const Timeout(Duration(seconds: 90)),
+  );
+
+  test(
     'Prints info when tab completions are not installed',
     () async {
       await withSidekickCli((cli) async {
         final p = await cli.run([]);
-        final stdout = await p.stderrStream().join('\n');
+        final stderr = await p.stderrStream().join('\n');
         expect(
-          stdout,
+          stderr,
           allOf([
             contains('💡Tip:'),
             contains('Run'),

--- a/sidekick/test/tab_completion_test.dart
+++ b/sidekick/test/tab_completion_test.dart
@@ -1,0 +1,60 @@
+import 'package:sidekick_core/sidekick_core.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+import 'util/cli_completion.dart';
+import 'util/cli_runner.dart';
+
+void main() {
+  /// Tests in this file install a sidekick CLI named 'dashi' globally.
+  /// To make sure this doesn't interfere with other tests, delete the symlink
+  void uninstallGlobalCli() {
+    // TODO use GlobalSidekickRoot.binDir when made available through updated sidekick_core dependency
+    final userHome = Platform.environment['HOME']!;
+    final sidekickBinDir = Directory('$userHome/.sidekick/bin');
+    // beware: sidekickBinDir.file('dashi').existsSync() always returns false because it's a link, not a file
+    final dashiSymLink = sidekickBinDir
+        .listSync()
+        .firstOrNullWhere((element) => element.name == 'dashi');
+
+    if (dashiSymLink != null) {
+      dashiSymLink.deleteSync();
+    }
+  }
+
+  setUp(uninstallGlobalCli);
+  tearDown(uninstallGlobalCli);
+
+  test('Prints info when tab completions are not installed', () async {
+    await withSidekickCli((cli) async {
+      final p = await cli.run([]);
+
+      final command = yellow('dashi sidekick install-global');
+      final expectedMessage =
+          '${cyan('Run')} $command ${cyan('to enable tab completion.')}';
+
+      final stdout = await p.stdoutStream().toList();
+      expect(stdout, contains(expectedMessage));
+    });
+  });
+
+  test('Tab prints completions', () async {
+    await withSidekickCli(
+      (cli) async {
+        await expectLater(
+          'dashi',
+          cli.suggests({
+            'dart': 'Calls dart',
+            'deps': 'Gets dependencies for all packages',
+            'clean': 'Cleans the project',
+            'analyze': 'Dart analyzes the whole project',
+            'format': 'Formats all Dart files in the repository.',
+            'sidekick': 'Manages the sidekick CLI',
+            '--help': 'Print this usage information.',
+            '--version': 'Print the sidekick version of this CLI.',
+          }),
+        );
+      },
+    );
+  });
+}

--- a/sidekick/test/tab_completion_test.dart
+++ b/sidekick/test/tab_completion_test.dart
@@ -58,6 +58,14 @@ void main() {
         final p = await cli.run(['sidekick', 'install-global']);
         final stderr = await p.stderrStream().join('\n');
 
+        late final String? startScript;
+        try {
+          // crashes in DockerShell on GitHub CI
+          startScript = Shell.current.pathToStartScript;
+        } catch (_) {
+          startScript = null;
+        }
+
         expect(
           stderr,
           isNot(
@@ -74,7 +82,7 @@ void main() {
             contains('Run'),
             contains('source'),
             anyOf([
-              contains(Shell.current.pathToStartScript),
+              if (startScript != null) contains(startScript),
               contains('~/.bashrc'),
             ]),
             contains('or restart your terminal to activate tab completion'),

--- a/sidekick/test/tab_completion_test.dart
+++ b/sidekick/test/tab_completion_test.dart
@@ -12,6 +12,9 @@ void main() {
     // TODO use GlobalSidekickRoot.binDir when made available through updated sidekick_core dependency
     final userHome = Platform.environment['HOME']!;
     final sidekickBinDir = Directory('$userHome/.sidekick/bin');
+    if (!sidekickBinDir.existsSync()) {
+      return;
+    }
     // beware: sidekickBinDir.file('dashi').existsSync() always returns false because it's a link, not a file
     final dashiSymLink = sidekickBinDir
         .listSync()

--- a/sidekick/test/tab_completion_test.dart
+++ b/sidekick/test/tab_completion_test.dart
@@ -33,14 +33,14 @@ void main() {
     () async {
       await withSidekickCli((cli) async {
         final p = await cli.run([]);
-        final stdout = await p.stderrStream().toList();
+        final stdout = await p.stderrStream().join('\n');
         expect(
           stdout,
-          containsAllInOrder([
-            '💡Tip:',
-            'Run',
-            './dashi sidekick install-global',
-            'to enable tab completion',
+          allOf([
+            contains('💡Tip:'),
+            contains('Run'),
+            contains('./dashi sidekick install-global'),
+            contains('to enable tab completion'),
           ]),
         );
       });

--- a/sidekick/test/test_runner.dart
+++ b/sidekick/test/test_runner.dart
@@ -38,5 +38,6 @@ void main() {
   group('init_test', init_test.main);
   group('plugins_test', plugins_test.main);
   group('recompile_test', recompile_test.main);
+  group('tab_completion_test', update_test.main);
   group('update_test', update_test.main);
 }

--- a/sidekick/test/test_runner.dart
+++ b/sidekick/test/test_runner.dart
@@ -6,6 +6,7 @@ import 'directory_extension_test.dart' as directory_extension_test;
 import 'init_test.dart' as init_test;
 import 'plugins_test.dart' as plugins_test;
 import 'recompile_test.dart' as recompile_test;
+import 'tab_completion_test.dart' as tab_completion_test;
 import 'update_test.dart' as update_test;
 import 'util/cli_runner.dart';
 
@@ -38,6 +39,6 @@ void main() {
   group('init_test', init_test.main);
   group('plugins_test', plugins_test.main);
   group('recompile_test', recompile_test.main);
-  group('tab_completion_test', update_test.main);
+  group('tab_completion_test', tab_completion_test.main);
   group('update_test', update_test.main);
 }

--- a/sidekick/test/util/cli_completion.dart
+++ b/sidekick/test/util/cli_completion.dart
@@ -1,0 +1,111 @@
+// Copied and adapted from package:cli_completion, file https://github.com/VeryGoodOpenSource/cli_completion/blob/a5b3571c03d964c08c6ce52b1cc907b2f93c0861/example/test/integration/utils.dart
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:sidekick_test/fake_stdio.dart';
+import 'package:test/test.dart';
+
+import 'cli_runner.dart';
+
+extension RunCompletionCommandExtension on SidekickCli {
+  /// Returns a matcher that matches if the tab completion of this CLI returns the given suggestions
+  ///
+  /// This is done by running the hidden 'completion' command of the CLI and checking its result
+  Matcher suggests(Map<String, String?> suggestions, {int? whenCursorIsAt}) =>
+      _CliCompletionMatcher(
+        suggestions,
+        cursorIndex: whenCursorIsAt,
+        cli: this,
+      );
+
+  Future<Map<String, String?>> _runCompletionCommand(
+    String line, {
+    int? cursorIndex,
+  }) async {
+    final map = <String, String?>{};
+
+    void onWriteln([Object? object]) {
+      // Simulate the shell behavior of interpreting the output of the completion.
+      final line = object! as String;
+
+      // A regex that finds all colons, except the ones preceded by backslash
+      final res = line.split(RegExp(r'(?<!\\):'));
+
+      final description = res.length > 1 ? res[1] : null;
+
+      map[res.first] = description;
+    }
+
+    final stdout = FakeStdoutStream(onWriteln: onWriteln);
+
+    return await IOOverrides.runZoned(
+      stdout: () => stdout,
+      () async {
+        final environmentOverride = {
+          'SHELL': '/foo/bar/zsh',
+          ..._prepareEnvForLineInput(line, cursorIndex: cursorIndex),
+        };
+        final process =
+            await run(['completion'], environment: environmentOverride);
+        final completions = await process.stdoutStream().toList();
+        final map = <String, String?>{};
+
+        for (final completionString in completions) {
+          // A regex that finds all colons, except the ones preceded by backslash
+          final res = completionString.split(RegExp(r'(?<!\\):'));
+
+          final description = res.length > 1 ? res[1] : null;
+
+          map[res.first] = description;
+        }
+
+        return map;
+      },
+    );
+  }
+}
+
+class _CliCompletionMatcher extends CustomMatcher {
+  final SidekickCli cli;
+
+  _CliCompletionMatcher(
+    Map<String, String?> suggestions, {
+    required this.cli,
+    this.cursorIndex,
+  }) : super(
+          'Completes with the expected suggestions',
+          'suggestions',
+          completion(suggestions),
+        );
+
+  final int? cursorIndex;
+
+  @override
+  Object? featureValueOf(dynamic line) {
+    if (line is! String) {
+      throw ArgumentError.value(line, 'line', 'must be a String');
+    }
+
+    return cli._runCompletionCommand(line, cursorIndex: cursorIndex);
+  }
+}
+
+/// Simulate the shell behavior of completing a command line.
+Map<String, String> _prepareEnvForLineInput(String line, {int? cursorIndex}) {
+  final cpoint = cursorIndex ?? line.length;
+  var cword = 0;
+  line.split(' ').fold(0, (value, element) {
+    final total = value + 1 + element.length;
+    if (total < cpoint) {
+      cword++;
+      return total;
+    }
+    return value;
+  });
+  return {
+    'COMP_LINE': line,
+    'COMP_POINT': '$cpoint',
+    'COMP_CWORD': '$cword',
+  };
+}

--- a/sidekick/test/util/cli_runner.dart
+++ b/sidekick/test/util/cli_runner.dart
@@ -135,14 +135,16 @@ class SidekickCli {
   SidekickCli._(this.root, this.name);
 
   /// Runs the CLI's entrypoint and verifies that it exits with exit code 0
-  Future<void> run(
+  Future<TestProcess> run(
     List<String> args, {
     Directory? workingDirectory,
+    Map<String, String>? environment,
   }) async {
     final process = await TestProcess.start(
       _entrypoint.path,
       args,
       workingDirectory: workingDirectory?.path ?? root.path,
+      environment: environment,
     );
 
     if (await process.exitCode != 0) {
@@ -150,5 +152,6 @@ class SidekickCli {
       process.stderrStream().listen(print);
     }
     await process.shouldExit(0);
+    return process;
   }
 }

--- a/sidekick_core/lib/sidekick_core.dart
+++ b/sidekick_core/lib/sidekick_core.dart
@@ -1,17 +1,9 @@
 /// The core library for Sidekick CLIs
 library sidekick_core;
 
-import 'dart:io';
-
-import 'package:args/args.dart';
-import 'package:args/command_runner.dart';
-import 'package:dartx/dartx_io.dart';
-import 'package:dcli/dcli.dart';
-import 'package:path/path.dart';
-import 'package:pub_semver/pub_semver.dart';
+import 'package:cli_completion/cli_completion.dart';
+import 'package:sidekick_core/sidekick_core.dart';
 import 'package:sidekick_core/src/commands/update_command.dart';
-import 'package:sidekick_core/src/dart_package.dart';
-import 'package:sidekick_core/src/repository.dart';
 import 'package:sidekick_core/src/sidekick_context.dart';
 import 'package:sidekick_core/src/version_checker.dart';
 
@@ -230,7 +222,7 @@ SidekickCommandRunner initializeSidekick({
 }
 
 /// A CommandRunner that makes lookups in [SidekickContext] faster
-class SidekickCommandRunner<T> extends CommandRunner<T> {
+class SidekickCommandRunner<T> extends CompletionCommandRunner<T> {
   SidekickCommandRunner._({
     required String description,
     this.mainProject,
@@ -243,6 +235,12 @@ class SidekickCommandRunner<T> extends CommandRunner<T> {
       help: 'Print the sidekick version of this CLI.',
     );
   }
+
+  // tab completion only works if the CLI is installed globally (run `<cli> sidekick install-global)
+  // if the CLI is not installed globally and the autocompletion script is invoked nonetheless,
+  // it prints an error message which is used as suggestion (<cli> _<cli>_completion:4: command not found: <cli>)
+  @override
+  bool get enableAutoInstall => isProgramInstalled(SidekickContext.cliName);
 
   @Deprecated('Use SidekickContext.projectRoot or SidekickContext.repository')
   Repository get repository => findRepository();
@@ -296,8 +294,25 @@ class SidekickCommandRunner<T> extends CommandRunner<T> {
       final result = await super.runCommand(parsedArgs);
       return result;
     } finally {
+      final reservedCommands = [
+        HandleCompletionRequestCommand.commandName,
+        InstallCompletionFilesCommand.commandName,
+      ];
+      // don't print anything additionally when running the hidden tab completion command (runs in the background when pressing tab),
+      // otherwise anything that is printed will also be used as suggestion
+      final isRunningTabCompletionCommand =
+          reservedCommands.contains(parsedArgs?.command?.name);
+
+      if (!enableAutoInstall && !isRunningTabCompletionCommand) {
+        final command =
+            yellow('${SidekickContext.cliName} sidekick install-global');
+        print('${cyan('Run')} $command ${cyan('to enable tab completion.')}');
+      }
+
       try {
-        if (_isUpdateCheckEnabled && !_isSidekickCliUpdateCommand(parsedArgs)) {
+        if (_isUpdateCheckEnabled &&
+            !_isSidekickCliUpdateCommand(parsedArgs) &&
+            !isRunningTabCompletionCommand) {
           // print warning if the user didn't fully update their CLI
           _checkCliVersionIntegrity();
           // print warning if CLI update is available

--- a/sidekick_core/lib/sidekick_core.dart
+++ b/sidekick_core/lib/sidekick_core.dart
@@ -294,25 +294,35 @@ class SidekickCommandRunner<T> extends CompletionCommandRunner<T> {
       final result = await super.runCommand(parsedArgs);
       return result;
     } finally {
-      final reservedCommands = [
-        HandleCompletionRequestCommand.commandName,
-        InstallCompletionFilesCommand.commandName,
-      ];
       // don't print anything additionally when running the hidden tab completion command (runs in the background when pressing tab),
       // otherwise anything that is printed will also be used as suggestion
-      final isRunningTabCompletionCommand =
-          reservedCommands.contains(parsedArgs?.command?.name);
+      bool isRunningTabCompletionCommand() {
+        final reservedCommands = [
+          HandleCompletionRequestCommand.commandName,
+          InstallCompletionFilesCommand.commandName,
+        ];
+        return reservedCommands.contains(parsedArgs?.command?.name);
+      }
 
-      if (!enableAutoInstall && !isRunningTabCompletionCommand) {
+      // don't show the install-global suggesting when running the install-global command
+      bool isInstallGlobalCommand() =>
+          parsedArgs?.command?.name == 'sidekick' &&
+          parsedArgs!.arguments.contains('install-global');
+
+      if (!enableAutoInstall &&
+          !isRunningTabCompletionCommand() &&
+          !isInstallGlobalCommand()) {
         final command =
-            yellow('${SidekickContext.cliName} sidekick install-global');
-        print('${cyan('Run')} $command ${cyan('to enable tab completion.')}');
+            yellow('./${SidekickContext.cliName} sidekick install-global');
+        printerr(
+          '${cyan('💡Tip: Run')} $command ${cyan('to enable tab completion.')}',
+        );
       }
 
       try {
         if (_isUpdateCheckEnabled &&
             !_isSidekickCliUpdateCommand(parsedArgs) &&
-            !isRunningTabCompletionCommand) {
+            !isRunningTabCompletionCommand()) {
           // print warning if the user didn't fully update their CLI
           _checkCliVersionIntegrity();
           // print warning if CLI update is available

--- a/sidekick_core/lib/src/commands/install_global_command.dart
+++ b/sidekick_core/lib/src/commands/install_global_command.dart
@@ -26,14 +26,26 @@ class InstallGlobalCommand extends Command {
 
     if (dcli.isOnPATH(GlobalSidekickRoot.binDir.path)) {
       print(
-        '\n'
-        "You can now use '${SidekickContext.cliName}' with tab completions from everywhere\n"
-        '\n',
+        "You can now use '${SidekickContext.cliName}' from everywhere\n",
       );
-      return;
+    } else {
+      _addBinDirToPathOrPrint();
     }
 
-    _addBinDirToPathOrPrint();
+    final String startScript = () {
+      try {
+        final path = Shell.current.pathToStartScript;
+        if (path != null) {
+          return path;
+        }
+      } catch (_) {
+        // ignore
+      }
+      return '~/.bashrc';
+    }();
+
+    print('Run ${cyan('source $startScript')} or restart your terminal '
+        'to activate tab completion');
   }
 
   void _addBinDirToPathOrPrint() {

--- a/sidekick_core/lib/src/commands/install_global_command.dart
+++ b/sidekick_core/lib/src/commands/install_global_command.dart
@@ -4,7 +4,8 @@ import 'package:sidekick_core/src/global_sidekick_root.dart';
 
 class InstallGlobalCommand extends Command {
   @override
-  final String description = 'Installs this custom sidekick CLI globally';
+  final String description =
+      'Installs this custom sidekick CLI globally and enables tab completion';
 
   @override
   final String name = 'install-global';
@@ -26,7 +27,7 @@ class InstallGlobalCommand extends Command {
     if (dcli.isOnPATH(GlobalSidekickRoot.binDir.path)) {
       print(
         '\n'
-        "You can now use '${SidekickContext.cliName}' from everywhere\n"
+        "You can now use '${SidekickContext.cliName}' with tab completions from everywhere\n"
         '\n',
       );
       return;

--- a/sidekick_core/lib/src/commands/install_global_command.dart
+++ b/sidekick_core/lib/src/commands/install_global_command.dart
@@ -44,7 +44,7 @@ class InstallGlobalCommand extends Command {
       return '~/.bashrc';
     }();
 
-    print('Run ${cyan('source $startScript')} or restart your terminal '
+    printerr('Run ${cyan('source $startScript')} or restart your terminal '
         'to activate tab completion');
   }
 

--- a/sidekick_core/pubspec.yaml
+++ b/sidekick_core/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 
 dependencies:
   args: ^2.1.0
+  cli_completion: ^0.3.0
   dartx: ^1.1.0
   dcli: '>=2.2.0 <=2.2.3'
   glob: ^2.0.2

--- a/sidekick_core/test/deps_command_test.dart
+++ b/sidekick_core/test/deps_command_test.dart
@@ -210,7 +210,7 @@ environment:
               '\n\nErrors while getting dependencies:',
               startsWith(
                 'broken: Failed to get dependencies for package ${brokenPubspec.parent.path}',
-              )
+              ),
             ]),
           );
         },

--- a/sidekick_core/test/format_command_test.dart
+++ b/sidekick_core/test/format_command_test.dart
@@ -398,7 +398,7 @@ name: dashi
               [
                 'Following Dart files are not formatted correctly:',
                 unformattedFile.path,
-                'Run "dash format" to format the code.'
+                'Run "dash format" to format the code.',
               ],
             ),
           ),

--- a/sidekick_core/test/sidekick_package_template_test.dart
+++ b/sidekick_core/test/sidekick_package_template_test.dart
@@ -50,7 +50,7 @@ void main() {
         'tool/install.sh',
         'tool/run.sh',
         'tool/download_dart.sh',
-        'tool/sidekick_config.sh'
+        'tool/sidekick_config.sh',
       };
       final expectedExecutables = {
         cliName,

--- a/sidekick_core/test/update/update_2_0_0_test.dart
+++ b/sidekick_core/test/update/update_2_0_0_test.dart
@@ -46,7 +46,7 @@ dependencies:
           },
           name: 'update sdk to 3.0',
           targetVersion: Version(2, 0, 0, pre: '1'),
-        )
+        ),
       ],
       onMigrationStepStart: (context) {
         print('Starting migration step ${context.step.name}');

--- a/sidekick_plugin_installer/lib/src/add_dependency.dart
+++ b/sidekick_plugin_installer/lib/src/add_dependency.dart
@@ -98,15 +98,15 @@ void addDependency({
       dependency,
     if (path) ...[
       '--path',
-      localPath
+      localPath,
     ] else if (hosted) ...[
       if (hostedUrl != null) ...['--hosted-url', hostedUrl],
     ] else if (git) ...[
       '--git-url',
       gitUrl!,
       if (gitRef != null) ...['--git-ref', gitRef],
-      if (gitPath != null) ...['--git-path', gitPath]
-    ]
+      if (gitPath != null) ...['--git-path', gitPath],
+    ],
   ];
 
   if (package.pubspec.readAsStringSync().contains('$dependency:')) {

--- a/sidekick_test/lib/src/fake_stdio.dart
+++ b/sidekick_test/lib/src/fake_stdio.dart
@@ -33,6 +33,9 @@ class FakeStdoutStream with Fake implements Stdout {
   void writeCharCode(int charCode) {
     _writes.add(utf8.encode(String.fromCharCode(charCode)));
   }
+
+  @override
+  bool get supportsAnsiEscapes => false;
 }
 
 T overrideIoStreams<T>({

--- a/sidekick_test/lib/src/local_testing.dart
+++ b/sidekick_test/lib/src/local_testing.dart
@@ -12,16 +12,19 @@ import 'package:test/test.dart';
 /// True when dependencies should be linked to local sidekick dependencies
 final bool shouldUseLocalDeps = env['SIDEKICK_PUB_DEPS'] != 'true';
 
+final String _gitRoot =
+    start('git rev-parse --show-toplevel', progress: Progress.capture())
+        .firstLine!;
+
 /// Changes the sidekick_core dependency to a local override
 void overrideSidekickCoreWithLocalPath(Directory package) {
   if (!shouldUseLocalDeps) return;
   print('Overriding sidekick_core dependency to local');
-  // assuming cwd when running those tests is in the sidekick package
-  final path = canonicalize('../sidekick_core');
+  final sidekickCorePath = canonicalize('$_gitRoot/sidekick_core');
   _overrideDependency(
     package: package,
     dependency: 'sidekick_core',
-    path: path,
+    path: sidekickCorePath,
   );
 }
 
@@ -29,12 +32,11 @@ void overrideSidekickCoreWithLocalPath(Directory package) {
 void overrideSidekickPluginInstallerWithLocalPath(Directory package) {
   if (!shouldUseLocalDeps) return;
   print('Overriding sidekick_plugin_installer dependency to local');
-  // assuming cwd when running those tests is in the sidekick package
-  final path = canonicalize('../sidekick_plugin_installer');
+  final sidekickCorePath = canonicalize('$_gitRoot/sidekick_plugin_installer');
   _overrideDependency(
     package: package,
     dependency: 'sidekick_plugin_installer',
-    path: path,
+    path: sidekickCorePath,
   );
 }
 
@@ -64,6 +66,9 @@ R insideFakeProjectWithSidekick<R>(
   String dartSdkConstraint = '>=2.14.0 <3.0.0',
   bool insideGitRepo = false,
 }) {
+  // initialize before overriding cwd
+  assert(_gitRoot.isNotEmpty);
+
   final tempDir = Directory.systemTemp.createTempSync();
   Directory projectRoot = tempDir;
   if (insideGitRepo) {

--- a/sk_sidekick/pubspec.lock
+++ b/sk_sidekick/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.0"
+  cli_completion:
+    dependency: transitive
+    description:
+      name: cli_completion
+      sha256: "595b192451285749369e99b3c2fd9a9aea7d74ed1aba61cddeb9ad8c84a44812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   cli_util:
     dependency: transitive
     description:
@@ -117,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -165,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: dartx
-      sha256: "45d7176701f16c5a5e00a4798791c1964bc231491b879369c818dd9a9c764871"
+      sha256: "8b25435617027257d43e6508b5fe061012880ddfdaa75a71d607c3de2a13d244"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   dcli:
     dependency: "direct main"
     description:
@@ -197,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   file:
     dependency: transitive
     description:
@@ -329,6 +337,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  mason_logger:
+    dependency: transitive
+    description:
+      name: mason_logger
+      sha256: c12860ae81f0bdc5d05d7914fe473bfb294047e9dc64e8995b5753c7207e81b9
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   matcher:
     dependency: transitive
     description:
@@ -555,10 +571,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
@@ -667,10 +683,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b8c67f5fa3897b122cf60fe9ff314f7b0ef71eab25c5f8b771480bc338f48823
+      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
       url: "https://pub.dev"
     source: hosted
-    version: "11.7.2"
+    version: "11.10.0"
   watcher:
     dependency: transitive
     description:

--- a/sk_sidekick/test/sidekick_context_test.dart
+++ b/sk_sidekick/test/sidekick_context_test.dart
@@ -14,6 +14,5 @@ void main() {
     expect(fakeStdOut.lines, contains('sidekickPackage: .'));
     expect(fakeStdOut.lines, contains('entryPoint: ../sk'));
     expect(fakeStdOut.lines, contains('projectRoot: ..'));
-    expect(fakeStdOut.lines.length, 3);
   });
 }


### PR DESCRIPTION
- The `sidekick` CLI now has tab completion by default
- Tab completion is enabled in all CLIs using the latest version of `sidekick_core` after running the `sidekick install-global` subcommand. If it isn't enabled yet, prints info about this

The shell completion files are installed after running any command without the need of an additional compilation step 😍 

[cli_completion docs explaining how completion works under the hood](https://github.com/VeryGoodOpenSource/cli_completion/tree/main/doc)