### PR TITLE
Make update check faster

### DIFF
--- a/sidekick_core/lib/sidekick_core.dart
+++ b/sidekick_core/lib/sidekick_core.dart
@@ -1,6 +1,8 @@
 /// The core library for Sidekick CLIs
 library sidekick_core;
 
+import 'dart:isolate';
+
 import 'package:cli_completion/cli_completion.dart';
 import 'package:sidekick_core/sidekick_core.dart';
 import 'package:sidekick_core/src/commands/update_command.dart';
@@ -295,7 +297,7 @@ class SidekickCommandRunner<T> extends CompletionCommandRunner<T> {
         // print warning if CLI update is available
         // TODO prevent multiple update checks when a command start another command
 
-        updateCheck = _checkForUpdates();
+        updateCheck = Isolate.run(_checkForUpdates);
       }
 
       if (parsedArgs['version'] == true) {


### PR DESCRIPTION
This PR is addressing this issue #174 

Starting the update check at the beginning of a command in an isolate and execute the returned function, which contains the `_checkCliVersionIntegrity` and may contain the print that an update is available