### PR TITLE
Force adding pubspec.lock regardless of other repo rules

### DIFF
--- a/sidekick_core/lib/src/template/sidekick_package.template.dart
+++ b/sidekick_core/lib/src/template/sidekick_package.template.dart
@@ -216,6 +216,9 @@ build/
 
 # Directory created by dartdoc
 doc/api/
+
+# Lock dependencies for deterministic builds on all systems
+!pubspec.lock
 ''';
 
 const String _analysisOptionsYaml = '''


### PR DESCRIPTION
Packages using `sidekick` usually ignore `pubspec.lock` in their repo `.gitignore`.
But the lock file is very important for sidekick, making sure the cli doesn't break on package updates like it happened here #251  