### PR TITLE
Max Dart SDK 3.2.X

### DIFF
--- a/sidekick_core/lib/src/commands/update_command.dart
+++ b/sidekick_core/lib/src/commands/update_command.dart
@@ -43,6 +43,12 @@ class UpdateCommand extends Command {
         .toList();
 
     final futureDartSdkVersionWithLatestPatch = futureDartSdkVersions
+        // Make the maximum compatible Dart SDK 3.2.x, because dcli is not
+        // compatible with Dart SDK 3.3.0 anymore
+        // Dart 3.3.0 waitFor requires --enable_deprecated_wait_for in the VM
+        // Dart 3.4.0 waitFor was removed
+        // Waiting for dcli 4.0.0 to be released https://github.com/onepub-dev/dcli/issues/229
+        .filter((version) => version < Version(3, 3, 0))
         .groupBy((v) => Version(v.major, v.minor, 0))
         .mapEntries((versionGroup) => versionGroup.value.maxBy((v) => v.patch)!)
         .toList();


### PR DESCRIPTION
Don't recommend Dart SDKs where the update would fail.

Waiting for dcli to update to 4.0
or remove dcli from sidekick_core #232 