### PR TITLE
Fix SdkInitializerContext.package when calling dart format

### DIFF
--- a/sidekick_core/lib/src/commands/format_command.dart
+++ b/sidekick_core/lib/src/commands/format_command.dart
@@ -106,6 +106,7 @@ class FormatCommand extends Command {
         lineLength: lineLength,
         files: allDartFiles,
         verify: verify,
+        workingDirectory: package.root,
       );
       _verifyThrow();
       return;
@@ -159,6 +160,7 @@ class FormatCommand extends Command {
     required int lineLength,
     required Iterable<File> files,
     bool verify = false,
+    Directory? workingDirectory,
   }) async {
     if (verify) {
       print("Verifying $name");
@@ -177,7 +179,7 @@ class FormatCommand extends Command {
         '-l',
         '$lineLength',
         if (!verify) '--fix',
-        ...files.map((file) => file.path),
+        ...files.map((file) => file.absolute.path),
         if (verify) '--set-exit-if-changed',
         if (verify) '--output=none',
       ],
@@ -185,6 +187,7 @@ class FormatCommand extends Command {
       // Lines like `Changed x.dart`, `Formatted x files (y changed) in z seconds`
       // should only be printed when the change is actually written to the files (when verify is false)
       progress: progress,
+      workingDirectory: workingDirectory,
     );
     exitCode = completion.exitCode ?? 1;
     if (exitCode != 0) {

--- a/sidekick_core/test/format_command_test.dart
+++ b/sidekick_core/test/format_command_test.dart
@@ -128,6 +128,11 @@ name: moshi
         final runner = initializeSidekick(
           dartSdkPath: systemDartSdkPath(),
         );
+
+        SdkInitializerContext? sdkInitializerContext;
+        addSdkInitializer((context) {
+          sdkInitializerContext = context;
+        });
         runner.addCommand(FormatCommand());
         await runner.run(['format', '-p', 'moshi']);
 
@@ -136,6 +141,11 @@ name: moshi
           _dartFile140,
         );
         expect(dir.file('moshi/lib/main.dart').readAsStringSync(), _dartFile80);
+        expect(sdkInitializerContext!.packageDir!.name, 'moshi');
+        expect(
+          sdkInitializerContext!.workingDirectory!.path,
+          dir.directory('moshi').path,
+        );
       });
     });
 


### PR DESCRIPTION
Now includes the package, when explicitly called for a package