### PR TITLE
Update pubspec_manager to 1.0.2

### DIFF
--- a/sidekick_core/pubspec.yaml
+++ b/sidekick_core/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   path: ^1.8.1
   # transitive from dcli
   pub_semver: ^2.1.1
-  pubspec_manager: ^1.0.1
+  pubspec_manager: ^1.0.2
   pubspec_parse: ^1.2.0
   recase: ^4.1.0
   # win32 is a transitive dependency of dcli, but dcli v7.0.2 requires win32 v5.7.0

--- a/sidekick_test/pubspec.yaml
+++ b/sidekick_test/pubspec.yaml
@@ -10,7 +10,10 @@ dependencies:
   args: ^2.1.0
   dartx: ^1.0.0
   dcli: ^7.0.2
-  mocktail: ^0.3.0
+  mocktail:
+    # Ignore comment on parsed pubspec.yaml
+    hosted: https://pub.dev
+    version: ^0.3.0
   path: ^1.8.1
   pubspec_manager: ^1.0.0
   test: '>1.25.0 <2.0.0'


### PR DESCRIPTION
Update to pubspec_manager 1.0.2 to fix an issue with the parsing of a pubspec.yaml with comments.
See: https://github.com/onepub-dev/pubspec_manager/issues/17