### PR TITLE
[internal] Make all "dart" functions futures

### DIFF
--- a/sidekick_core/lib/src/commands/plugins/create_plugin_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/create_plugin_command.dart
@@ -94,10 +94,10 @@ class CreatePluginCommand extends Command {
 
     if (usingGlobalSidekickCli) {
       // command is run from global sidekick CLI
-      systemDart(formatArgs);
+      await systemDart(formatArgs);
     } else {
       // command is run from generated sidekick CLI which has its own Dart SDK
-      sidekickDartRuntime.dart(formatArgs);
+      await sidekickDartRuntime.dart(formatArgs);
     }
   }
 }

--- a/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
+++ b/sidekick_core/lib/src/commands/plugins/install_plugin_command.dart
@@ -74,7 +74,7 @@ class InstallPluginCommand extends Command {
     );
     env['SIDEKICK_PLUGIN_VERSION_CONSTRAINT'] = versionConstraint;
 
-    final Directory pluginInstallerDir = () {
+    final Directory pluginInstallerDir = await () async {
       switch (source) {
         case 'path':
           final dir = Directory(packageNameOrGitUrlOrLocalPath);
@@ -94,13 +94,13 @@ class InstallPluginCommand extends Command {
         case 'hosted':
           env['SIDEKICK_PLUGIN_HOSTED_URL'] = args['hosted-url'] as String?;
           print('Downloading from pub $packageNameOrGitUrlOrLocalPath...');
-          return _getPackageRootDirForHostedOrGitSource(args);
+          return await _getPackageRootDirForHostedOrGitSource(args);
         case 'git':
           env['SIDEKICK_PLUGIN_GIT_URL'] = packageNameOrGitUrlOrLocalPath;
           env['SIDEKICK_PLUGIN_GIT_REF'] = gitRef;
           env['SIDEKICK_PLUGIN_GIT_PATH'] = gitPath;
           print('Downloading from git $packageNameOrGitUrlOrLocalPath...');
-          return _getPackageRootDirForHostedOrGitSource(args);
+          return await _getPackageRootDirForHostedOrGitSource(args);
         default:
           throw StateError('unreachable');
       }
@@ -142,7 +142,7 @@ class InstallPluginCommand extends Command {
     // get installer dependencies
     final capture = Progress.capture();
     try {
-      sidekickDartRuntime.dart(
+      await sidekickDartRuntime.dart(
         ['pub', 'get'],
         workingDirectory: workingDir,
         progress: capture,
@@ -207,7 +207,7 @@ class InstallPluginCommand extends Command {
     if (!installScript.existsSync()) {
       throw 'No ${installScript.path} script found in package at $pluginInstallerDir';
     }
-    sidekickDartRuntime.dart(
+    await sidekickDartRuntime.dart(
       [installScript.path],
       workingDirectory: target.root,
     );
@@ -224,7 +224,8 @@ class InstallPluginCommand extends Command {
 }
 
 // Welcome to the world of magic
-Directory _getPackageRootDirForHostedOrGitSource(ArgResults args) {
+Future<Directory> _getPackageRootDirForHostedOrGitSource(
+    ArgResults args) async {
   // TODO Maybe we should do a `dart pub global list` first to check if
   // the package is already activated. If it is already activated,
   // we should at least print a warning because we are altering the
@@ -258,7 +259,7 @@ Directory _getPackageRootDirForHostedOrGitSource(ArgResults args) {
     captureStderr: true,
   );
   try {
-    sidekickDartRuntime.dart(pubGlobalActivateArgs, progress: progress);
+    await sidekickDartRuntime.dart(pubGlobalActivateArgs, progress: progress);
   } catch (e) {
     // TODO for git-ref and git-path args we could add a check way earlier:
     // when the sidekick Dart version is too low either throw if the arg is given or hide the arg
@@ -329,7 +330,7 @@ Directory _getPackageRootDirForHostedOrGitSource(ArgResults args) {
 
   // TODO Don't deactivate when the package was already activated
   // The package was only activated to cache it and can be deactivated now
-  sidekickDartRuntime.dart(
+  await sidekickDartRuntime.dart(
     [
       'pub',
       'global',

--- a/sidekick_core/lib/src/dart.dart
+++ b/sidekick_core/lib/src/dart.dart
@@ -78,13 +78,13 @@ class DartSdkNotSetException implements Exception {
 ///
 /// If [throwOnError] is given and the command returns a non-zero exit code,
 /// the result of [throwOnError] will be thrown regardless of [nothrow]
-int systemDart(
+Future<int> systemDart(
   List<String> args, {
   Directory? workingDirectory,
   dcli.Progress? progress,
   bool nothrow = false,
   String Function()? throwOnError,
-}) {
+}) async {
   final systemDartExecutablePath = systemDartExecutable();
   if (systemDartExecutablePath == null) {
     throw "Couldn't find dart executable on PATH.";

--- a/sidekick_core/lib/src/dart_runtime.dart
+++ b/sidekick_core/lib/src/dart_runtime.dart
@@ -46,12 +46,12 @@ class SidekickDartRuntime {
   }
 
   /// Runs custom dart executable of this runtime
-  void dart(
+  Future<void> dart(
     List<String> args, {
     Directory? workingDirectory,
     dcli.Progress? progress,
     bool nothrow = false,
-  }) {
+  }) async {
     dcli.startFromArgs(
       _dartExecutable.path,
       args,

--- a/sidekick_core/lib/src/update/major_update_dependencies_migration.dart
+++ b/sidekick_core/lib/src/update/major_update_dependencies_migration.dart
@@ -8,7 +8,7 @@ class MajorUpdateDependenciesMigration extends MigrationStep {
 
   @override
   Future<void> migrate(MigrationContext context) async {
-    sidekickDartRuntime.dart(
+    await sidekickDartRuntime.dart(
       ['pub', 'upgrade', '--major-versions'],
       workingDirectory: SidekickContext.sidekickPackage.root,
     );


### PR DESCRIPTION
Since the `dart` function was converted a to a future, The `_dartCommand` was either a future or now future. This lead to the error that the function was sometimes not awaited! 😱

All dart functions are now futures!