### PR TITLE
Add dart-internal command for direct access to embedded Dart SDK

### DIFF
--- a/sidekick_core/lib/src/commands/dart_internal_command.dart
+++ b/sidekick_core/lib/src/commands/dart_internal_command.dart
@@ -1,0 +1,31 @@
+import 'package:sidekick_core/sidekick_core.dart';
+
+/// Executes the embedded Dart SDK managed by sidekick
+///
+/// This command provides direct access to the Dart runtime that sidekick
+/// downloads and manages, allowing execution of Dart commands using the
+/// same SDK version as the CLI.
+///
+/// Usage examples:
+///   `<cli> sidekick dart-internal --version`
+///   `<cli> sidekick dart-internal pub get`
+///   `<cli> sidekick dart-internal run main.dart`
+///
+/// Note: This command is intercepted by the bash script and never actually
+/// executed by the Dart CLI. It exists only for documentation in help output.
+class DartInternalCommand extends Command {
+  @override
+  final String description =
+      'Executes the embedded Dart SDK managed by sidekick (useful for recovery when CLI compilation fails)';
+
+  @override
+  final String name = 'dart-internal';
+
+  @override
+  Future<void> run() {
+    throw StateError(
+      'This command should never be executed. '
+      'It is intercepted by the bash script.',
+    );
+  }
+}

--- a/sidekick_core/lib/src/commands/sidekick_command.dart
+++ b/sidekick_core/lib/src/commands/sidekick_command.dart
@@ -1,5 +1,6 @@
 import 'package:sidekick_core/sidekick_core.dart';
 import 'package:sidekick_core/src/commands/create_command_command.dart';
+import 'package:sidekick_core/src/commands/dart_internal_command.dart';
 import 'package:sidekick_core/src/commands/update_command.dart';
 
 /// Sidekick CLI tools directly shipped from the sidekick_core package
@@ -13,6 +14,7 @@ class SidekickCommand extends Command {
   SidekickCommand() {
     addSubcommand(PluginsCommand());
     addSubcommand(CreateCommandCommand());
+    addSubcommand(DartInternalCommand());
     addSubcommand(RecompileCommand());
     addSubcommand(InstallGlobalCommand());
     addSubcommand(UpdateCommand());

--- a/sidekick_core/lib/src/template/run.sh.template.dart
+++ b/sidekick_core/lib/src/template/run.sh.template.dart
@@ -81,6 +81,13 @@ if [ ! -f "$EXE" ] || [ "$HASH" != "$EXISTING_HASH" ]; then
   echo "$NEW_HASH" > "$STAMP_FILE"
 fi
 
+# Handle sidekick dart-internal command
+if [ "$1" = "sidekick" ] && [ "$2" = "dart-internal" ]; then
+  shift 2
+  "${DART_SDK}/bin/dart" "$@"
+  exit $?
+fi
+
 "${EXE}" "$@"
 
 ''';


### PR DESCRIPTION
This PR adds a new dart-internal command that provides direct access to the embedded Dart SDK managed by sidekick. Useful for recovery scenarios when CLI is broken.