### PR TITLE
[format] Hide excludeGlob excluded packages entirely from output

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -18,12 +18,5 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: check formatting
-        run: |
-          dart format --fix --output none --set-exit-if-changed \
-          sidekick/bin sidekick/lib sidekick/test \
-          sidekick_core \
-          sidekick_plugin_installer \
-          sidekick_test \
-          sidekick_vault \
-          sk_sidekick/lib
+        run: ./sk format --verify
           

--- a/sk_sidekick/lib/sk_sidekick.dart
+++ b/sk_sidekick/lib/sk_sidekick.dart
@@ -23,7 +23,7 @@ Future<void> runSk(List<String> args) async {
     ..addCommand(DartCommand())
     ..addCommand(DepsCommand(excludeGlob: ['**/templates/**']))
     ..addCommand(DartAnalyzeCommand())
-    ..addCommand(FormatCommand())
+    ..addCommand(FormatCommand(excludeGlob: ['**/test/templates/**']))
     ..addCommand(LockDependenciesCommand())
     ..addCommand(ReleaseCommand())
     ..addCommand(TestCommand())


### PR DESCRIPTION
Even when entire package where excluded by glob, they where printed to the console

```
Formatting package:package_b
No files to format
Formatting package:package_a
No files to format
Formatting package:minimal
No files to format
Formatting package:minimal_sidekick_plugin
No files to format
Formatting package:minimal
No files to format
Formatting package:root_with_packages
No files to format
Formatting package:sidekick_plugin_installer
Formatted 9 files (0 changed) in 0.20 seconds.
Formatting package:sidekick_vault
Formatted 11 files (0 changed) in 0.25 seconds.
Formatting package:sidekick_test
Formatted 9 files (0 changed) in 0.19 seconds.
Formatting package:sidekick_core
Formatted 77 files (0 changed) in 0.54 seconds.
Formatting package:sk_sidekick
Formatted 13 files (0 changed) in 0.32 seconds.
Formatting package:sidekick
Formatted 19 files (0 changed) in 0.29 seconds.
```

Now those are actually ignored

```
Formatting package:sidekick_plugin_installer
Formatted 9 files (0 changed) in 0.20 seconds.
Formatting package:sidekick_vault
Formatted 11 files (0 changed) in 0.25 seconds.
Formatting package:sidekick_test
Formatted 9 files (0 changed) in 0.19 seconds.
Formatting package:sidekick_core
Formatted 77 files (0 changed) in 0.54 seconds.
Formatting package:sk_sidekick
Formatted 13 files (0 changed) in 0.32 seconds.
Formatting package:sidekick
Formatted 19 files (0 changed) in 0.29 seconds.
```

 