### PR TITLE
Strip dev_dependencies before locking release deps

### DIFF
--- a/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
+++ b/sk_sidekick/lib/src/commands/lock_dependencies_command.dart
@@ -1,4 +1,5 @@
 import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_manager/pubspec_manager.dart' as pm;
 import 'package:sidekick_core/sidekick_core.dart' hide version;
 // ignore: implementation_imports, sk_sidekick is not a published package and already depends on sidekick_core from path
 import 'package:sidekick_core/src/version_checker.dart';
@@ -49,104 +50,126 @@ class LockDependenciesCommand extends Command {
       pubspecOverrides.deleteSync();
     }
 
-    systemDart(
-      ['pub', 'get'],
-      workingDirectory: package.root,
-      throwOnError: () => "Couldn't update dependencies in ${package.root}",
-    );
+    final originalPubspecContent = package.pubspec.readAsStringSync();
 
-    final lockfile = package.lockfile;
-    if (!lockfile.existsSync()) {
-      throw "Lockfile doesn't exist in ${package.root}";
+    // Strip dev_dependencies before resolving. Their transitives (e.g.
+    // analyzer via test → test_core → analyzer) would otherwise get pinned
+    // as direct dependencies and constrain downstream consumers running
+    // `pub global activate`, even though dev dependencies are not part of
+    // the activation closure.
+    final editable = pm.PubSpec.loadFromString(originalPubspecContent);
+    final devDepNames = editable.devDependencies.list
+        .map((d) => d.name)
+        .toList();
+    for (final name in devDepNames) {
+      editable.devDependencies.remove(name);
     }
+    package.pubspec.writeAsStringSync(editable.toString());
 
-    final constrainedVersions =
-        (loadYaml(package.pubspec.readAsStringSync())
-                as YamlMap)['dependencies']
-            as YamlMap;
-    final lockedVersions =
-        // ignore: avoid_dynamic_calls
-        loadYaml(lockfile.readAsStringSync())['packages'] as YamlMap;
-
-    final Map<String, VersionRange> directDependencies = {};
-    final Map<String, VersionRange> transitiveDependencies = {};
-    for (final package in lockedVersions.entries) {
-      final value = package.value as YamlMap;
-      final type = value['dependency'];
-      final packageName = package.key as String;
-      final Version latestVersion = Version.parse(value['version'] as String);
-      final VersionRange? constraints = () {
-        try {
-          final rawConstraints = constrainedVersions[packageName] as String?;
-          return VersionConstraint.parse(rawConstraints!) as VersionRange;
-        } catch (e) {
-          return null;
-        }
-      }();
-
-      if (type != 'direct dev' && value['source'] != 'hosted') {
-        throw "Can only handle dependencies from hosted sources, but $packageName violates this.";
-      }
-
-      final VersionRange range;
-      if (constraints == null) {
-        // Not a direct dependency,
-        final lowerBound = latestVersion.major > 0
-            ? Version(latestVersion.major, 0, 0)
-            : Version(0, latestVersion.minor, 0);
-        range = VersionRange(
-          min: lowerBound,
-          max: latestVersion,
-          includeMax: true,
-          includeMin: true,
-        );
-      } else {
-        // Direct dependency with constraints
-        // Combines latest version from pub (lock file) with the version
-        // constraints from the pubspec.yaml file
-        range = VersionRange(
-          min: constraints.min,
-          max: latestVersion,
-          includeMax: true,
-          includeMin: true,
-        );
-      }
-      assert(
-        range.allows(latestVersion),
-        'Latest version $latestVersion is not allowed by $range',
+    final String lockedDependencies;
+    try {
+      systemDart(
+        ['pub', 'get'],
+        workingDirectory: package.root,
+        throwOnError: () => "Couldn't update dependencies in ${package.root}",
       );
 
-      switch (type) {
-        case 'transitive':
-          transitiveDependencies[packageName] = range;
-        case 'direct main':
-          directDependencies[packageName] = range;
-        // case 'direct dev' is irrelevant
+      final lockfile = package.lockfile;
+      if (!lockfile.existsSync()) {
+        throw "Lockfile doesn't exist in ${package.root}";
       }
+
+      final constrainedVersions =
+          (loadYaml(package.pubspec.readAsStringSync())
+                  as YamlMap)['dependencies']
+              as YamlMap;
+      final lockedVersions =
+          // ignore: avoid_dynamic_calls
+          loadYaml(lockfile.readAsStringSync())['packages'] as YamlMap;
+
+      final Map<String, VersionRange> directDependencies = {};
+      final Map<String, VersionRange> transitiveDependencies = {};
+      for (final package in lockedVersions.entries) {
+        final value = package.value as YamlMap;
+        final type = value['dependency'];
+        final packageName = package.key as String;
+        final Version latestVersion = Version.parse(value['version'] as String);
+        final VersionRange? constraints = () {
+          try {
+            final rawConstraints = constrainedVersions[packageName] as String?;
+            return VersionConstraint.parse(rawConstraints!) as VersionRange;
+          } catch (e) {
+            return null;
+          }
+        }();
+
+        if (value['source'] != 'hosted') {
+          throw "Can only handle dependencies from hosted sources, but $packageName violates this.";
+        }
+
+        final VersionRange range;
+        if (constraints == null) {
+          // Not a direct dependency,
+          final lowerBound = latestVersion.major > 0
+              ? Version(latestVersion.major, 0, 0)
+              : Version(0, latestVersion.minor, 0);
+          range = VersionRange(
+            min: lowerBound,
+            max: latestVersion,
+            includeMax: true,
+            includeMin: true,
+          );
+        } else {
+          // Direct dependency with constraints
+          // Combines latest version from pub (lock file) with the version
+          // constraints from the pubspec.yaml file
+          range = VersionRange(
+            min: constraints.min,
+            max: latestVersion,
+            includeMax: true,
+            includeMin: true,
+          );
+        }
+        assert(
+          range.allows(latestVersion),
+          'Latest version $latestVersion is not allowed by $range',
+        );
+
+        switch (type) {
+          case 'transitive':
+            transitiveDependencies[packageName] = range;
+          case 'direct main':
+            directDependencies[packageName] = range;
+        }
+      }
+
+      final pinnedDirectDependencies = directDependencies
+          .mapEntries((e) => "  ${e.key}: '${e.value}'")
+          .sorted();
+      final pinnedTransitiveDependencies = transitiveDependencies
+          .mapEntries((e) => "  ${e.key}: '${e.value}'")
+          .sorted();
+
+      lockedDependencies = [
+        'dependencies:',
+        '  # direct dependencies',
+        ...pinnedDirectDependencies,
+        '',
+        '  # transitive dependencies',
+        ...pinnedTransitiveDependencies,
+      ].join('\n');
+    } finally {
+      // Restore the original pubspec (with dev_dependencies) so the locked
+      // pubspec keeps the full dev setup intact.
+      package.pubspec.writeAsStringSync(originalPubspecContent);
     }
-
-    final pinnedDirectDependencies = directDependencies
-        .mapEntries((e) => "  ${e.key}: '${e.value}'")
-        .sorted();
-    final pinnedTransitiveDependencies = transitiveDependencies
-        .mapEntries((e) => "  ${e.key}: '${e.value}'")
-        .sorted();
-
-    final lockedDependencies = [
-      'dependencies:',
-      '  # direct dependencies',
-      ...pinnedDirectDependencies,
-      '',
-      '  # transitive dependencies',
-      ...pinnedTransitiveDependencies,
-    ].join('\n');
 
     final currentDependenciesBlock = RegExp(
       r'^dependencies:.*((\n\s*#.*)|(\n {2}.*))*',
       multiLine: true,
-    ).firstMatch(package.pubspec.readAsStringSync())?.group(0);
+    ).firstMatch(originalPubspecContent)?.group(0);
     if (currentDependenciesBlock == null) {
-      throw "Couldn't parse current dependencies block in ${package.pubspec.path}: ${package.pubspec.readAsStringSync()}";
+      throw "Couldn't parse current dependencies block in ${package.pubspec.path}: $originalPubspecContent";
     }
 
     package.pubspec.copySync('${package.pubspec.absolute.path}.unlocked');


### PR DESCRIPTION
`sk release` ran `lock-dependencies` against the full pubspec, so dev-only transitives (e.g. `analyzer` via `test → test_core`) were pinned as direct dependencies in the published package. `analyzer 10.0.0` requires Dart `^3.9.0`, so `dart pub global activate sidekick` silently downgraded to 3.0.0 on Dart 3.6 – 3.8.

Strip `dev_dependencies` before `dart pub get`, then restore before writing the locked pubspec.

Before, locked `sidekick/pubspec.yaml`:

```yaml
# transitive dependencies
_fe_analyzer_shared: '>=93.0.0 <=93.0.0'
analyzer: '>=10.0.0 <=10.0.0'
coverage: '>=1.0.0 <=1.15.0'
test_api: '>=0.7.0 <=0.7.9'
test_core: '>=0.6.0 <=0.6.15'
…
```

After: those entries are gone.

Only affects future releases. `sidekick 3.1.0` on pub.dev still has the bad pin and needs a re-release.